### PR TITLE
feat: migrate iOS from deprecated objc 0.2 to objc2 0.6 (fixes #31)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ gpui = { git = "https://github.com/zed-industries/zed", rev = "56104fb17e6c58499
 
 [target.'cfg(target_os = "ios")'.dependencies]
 # Objective-C runtime
-objc2 = "0.5"
+objc2 = "0.6"
 
 # Apple frameworks
 core-foundation     = "0.10"
@@ -76,7 +76,7 @@ core-foundation-sys = "0.8"
 core-graphics       = "0.24"
 core-text           = "=21.0.0"
 uuid                = { version = "1", features = ["v4", "v5"] }
-block               = "0.1"
+block2              = "0.6"
 
 # wgpu renderer (Metal backend on iOS/Android)
 gpui_wgpu = { git = "https://github.com/zed-industries/zed", rev = "56104fb17e6c5849900a4c282f42d1bfea294121", package = "gpui_wgpu", features = ["font-kit"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ gpui = { git = "https://github.com/zed-industries/zed", rev = "56104fb17e6c58499
 
 [target.'cfg(target_os = "ios")'.dependencies]
 # Objective-C runtime
-objc = "0.2"
+objc2 = "0.5"
 
 # Apple frameworks
 core-foundation     = "0.10"

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -22,7 +22,7 @@ reqwest = { git = "https://github.com/zed-industries/reqwest.git", rev = "c15662
 log = "0.4"
 
 [target.'cfg(target_os = "ios")'.dependencies]
-objc = "0.2"
+objc2 = "0.5"
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_logger = "0.15"

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -22,7 +22,7 @@ reqwest = { git = "https://github.com/zed-industries/reqwest.git", rev = "c15662
 log = "0.4"
 
 [target.'cfg(target_os = "ios")'.dependencies]
-objc2 = "0.5"
+objc2 = "0.6"
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_logger = "0.15"

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -162,15 +162,16 @@ impl log::Log for NsLogLogger {
 /// Call NSLog from Rust via raw FFI.
 #[cfg(target_os = "ios")]
 fn nslog(msg: &str) {
-    use objc::{class, msg_send, runtime::Object, sel, sel_impl};
+    use objc2::runtime::AnyObject;
+    use objc2::{class, msg_send};
     unsafe {
-        extern "C" { fn NSLog(fmt: *mut Object, ...); }
+        extern "C" { fn NSLog(fmt: *mut AnyObject, ...); }
         let c_msg = std::ffi::CString::new(msg).unwrap_or_default();
-        let ns_msg: *mut Object = msg_send![class!(NSString), alloc];
-        let ns_msg: *mut Object = msg_send![ns_msg, initWithUTF8String: c_msg.as_ptr()];
+        let ns_msg: *mut AnyObject = msg_send![class!(NSString), alloc];
+        let ns_msg: *mut AnyObject = msg_send![ns_msg, initWithUTF8String: c_msg.as_ptr()];
         let c_fmt = std::ffi::CString::new("%@").unwrap_or_default();
-        let ns_fmt: *mut Object = msg_send![class!(NSString), alloc];
-        let ns_fmt: *mut Object = msg_send![ns_fmt, initWithUTF8String: c_fmt.as_ptr()];
+        let ns_fmt: *mut AnyObject = msg_send![class!(NSString), alloc];
+        let ns_fmt: *mut AnyObject = msg_send![ns_fmt, initWithUTF8String: c_fmt.as_ptr()];
         NSLog(ns_fmt, ns_msg);
     }
 }

--- a/src/ios/cg_types.rs
+++ b/src/ios/cg_types.rs
@@ -48,13 +48,24 @@ impl ObjcCGRect {
 
     pub fn to_cg(self) -> CGRect {
         CGRect {
-            origin: CGPoint { x: self.x, y: self.y },
-            size: CGSize { width: self.width, height: self.height },
+            origin: CGPoint {
+                x: self.x,
+                y: self.y,
+            },
+            size: CGSize {
+                width: self.width,
+                height: self.height,
+            },
         }
     }
 
     pub fn new(x: f64, y: f64, width: f64, height: f64) -> Self {
-        Self { x, y, width, height }
+        Self {
+            x,
+            y,
+            width,
+            height,
+        }
     }
 }
 
@@ -69,8 +80,7 @@ pub struct ObjcCGPoint {
 }
 
 unsafe impl Encode for ObjcCGPoint {
-    const ENCODING: Encoding =
-        Encoding::Struct("CGPoint", &[Encoding::Double, Encoding::Double]);
+    const ENCODING: Encoding = Encoding::Struct("CGPoint", &[Encoding::Double, Encoding::Double]);
 }
 
 unsafe impl RefEncode for ObjcCGPoint {
@@ -79,7 +89,10 @@ unsafe impl RefEncode for ObjcCGPoint {
 
 impl ObjcCGPoint {
     pub fn to_cg(self) -> CGPoint {
-        CGPoint { x: self.x, y: self.y }
+        CGPoint {
+            x: self.x,
+            y: self.y,
+        }
     }
 }
 
@@ -94,8 +107,7 @@ pub struct ObjcCGSize {
 }
 
 unsafe impl Encode for ObjcCGSize {
-    const ENCODING: Encoding =
-        Encoding::Struct("CGSize", &[Encoding::Double, Encoding::Double]);
+    const ENCODING: Encoding = Encoding::Struct("CGSize", &[Encoding::Double, Encoding::Double]);
 }
 
 unsafe impl RefEncode for ObjcCGSize {
@@ -104,6 +116,9 @@ unsafe impl RefEncode for ObjcCGSize {
 
 impl ObjcCGSize {
     pub fn to_cg(self) -> CGSize {
-        CGSize { width: self.width, height: self.height }
+        CGSize {
+            width: self.width,
+            height: self.height,
+        }
     }
 }

--- a/src/ios/cg_types.rs
+++ b/src/ios/cg_types.rs
@@ -1,0 +1,109 @@
+//! Local wrappers for CoreGraphics geometry types with objc2::Encode impls.
+//!
+//! `core-graphics` types (CGRect, CGPoint, CGSize) do not implement
+//! `objc2::encode::Encode` because the `core-graphics` crate predates
+//! objc2's encoding system. We define `#[repr(C)]` newtype wrappers with the
+//! same memory layout and provide the needed impls, then offer cheap
+//! conversion helpers.
+
+use core_graphics::geometry::{CGPoint, CGRect, CGSize};
+use objc2::encode::{Encode, Encoding, RefEncode};
+
+// ── CGRect ────────────────────────────────────────────────────────────────────
+
+/// objc2-encodable mirror of `core_graphics::geometry::CGRect`.
+/// Layout: `{ origin: { x: f64, y: f64 }, size: { width: f64, height: f64 } }`
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ObjcCGRect {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+}
+
+unsafe impl Encode for ObjcCGRect {
+    const ENCODING: Encoding = Encoding::Struct(
+        "CGRect",
+        &[
+            Encoding::Struct("CGPoint", &[Encoding::Double, Encoding::Double]),
+            Encoding::Struct("CGSize", &[Encoding::Double, Encoding::Double]),
+        ],
+    );
+}
+
+unsafe impl RefEncode for ObjcCGRect {
+    const ENCODING_REF: Encoding = Encoding::Pointer(&Self::ENCODING);
+}
+
+impl ObjcCGRect {
+    pub fn from_cg(r: CGRect) -> Self {
+        Self {
+            x: r.origin.x,
+            y: r.origin.y,
+            width: r.size.width,
+            height: r.size.height,
+        }
+    }
+
+    pub fn to_cg(self) -> CGRect {
+        CGRect {
+            origin: CGPoint { x: self.x, y: self.y },
+            size: CGSize { width: self.width, height: self.height },
+        }
+    }
+
+    pub fn new(x: f64, y: f64, width: f64, height: f64) -> Self {
+        Self { x, y, width, height }
+    }
+}
+
+// ── CGPoint ───────────────────────────────────────────────────────────────────
+
+/// objc2-encodable mirror of `core_graphics::geometry::CGPoint`.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ObjcCGPoint {
+    pub x: f64,
+    pub y: f64,
+}
+
+unsafe impl Encode for ObjcCGPoint {
+    const ENCODING: Encoding =
+        Encoding::Struct("CGPoint", &[Encoding::Double, Encoding::Double]);
+}
+
+unsafe impl RefEncode for ObjcCGPoint {
+    const ENCODING_REF: Encoding = Encoding::Pointer(&Self::ENCODING);
+}
+
+impl ObjcCGPoint {
+    pub fn to_cg(self) -> CGPoint {
+        CGPoint { x: self.x, y: self.y }
+    }
+}
+
+// ── CGSize ────────────────────────────────────────────────────────────────────
+
+/// objc2-encodable mirror of `core_graphics::geometry::CGSize`.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ObjcCGSize {
+    pub width: f64,
+    pub height: f64,
+}
+
+unsafe impl Encode for ObjcCGSize {
+    const ENCODING: Encoding =
+        Encoding::Struct("CGSize", &[Encoding::Double, Encoding::Double]);
+}
+
+unsafe impl RefEncode for ObjcCGSize {
+    const ENCODING_REF: Encoding = Encoding::Pointer(&Self::ENCODING);
+}
+
+impl ObjcCGSize {
+    pub fn to_cg(self) -> CGSize {
+        CGSize { width: self.width, height: self.height }
+    }
+}

--- a/src/ios/dispatcher.rs
+++ b/src/ios/dispatcher.rs
@@ -10,11 +10,8 @@
 use gpui::{PlatformDispatcher, Priority, RunnableVariant, ThreadTaskTimings};
 use std::thread;
 
-use objc::{
-    class, msg_send,
-    runtime::{BOOL, YES},
-    sel, sel_impl,
-};
+use objc2::ffi::{BOOL, YES};
+use objc2::{class, msg_send, sel};
 use std::{ffi::c_void, ptr::NonNull, time::Duration};
 
 // GCD types - these are the same on iOS and macOS

--- a/src/ios/display.rs
+++ b/src/ios/display.rs
@@ -6,14 +6,14 @@
 use anyhow::Result;
 use core_graphics::geometry::CGRect;
 use gpui::{px, size, Bounds, DisplayId, Pixels, PlatformDisplay};
-use objc::{class, msg_send, sel, sel_impl};
+use objc2::{class, msg_send, sel};
 use uuid::Uuid;
 
 /// Represents an iOS display (UIScreen).
 #[derive(Debug)]
 pub(crate) struct IosDisplay {
     /// The UIScreen object
-    screen: *mut objc::runtime::Object,
+    screen: *mut objc2::runtime::AnyObject,
 }
 
 unsafe impl Send for IosDisplay {}
@@ -23,7 +23,7 @@ impl IosDisplay {
     /// Get the main screen.
     pub fn main() -> Self {
         unsafe {
-            let screen: *mut objc::runtime::Object = msg_send![class!(UIScreen), mainScreen];
+            let screen: *mut objc2::runtime::AnyObject = msg_send![class!(UIScreen), mainScreen];
             Self { screen }
         }
     }
@@ -31,11 +31,11 @@ impl IosDisplay {
     /// Get all connected screens.
     pub fn all() -> impl Iterator<Item = Self> {
         unsafe {
-            let screens: *mut objc::runtime::Object = msg_send![class!(UIScreen), screens];
+            let screens: *mut objc2::runtime::AnyObject = msg_send![class!(UIScreen), screens];
             let count: usize = msg_send![screens, count];
 
             (0..count).map(move |i| {
-                let screen: *mut objc::runtime::Object = msg_send![screens, objectAtIndex: i];
+                let screen: *mut objc2::runtime::AnyObject = msg_send![screens, objectAtIndex: i];
                 Self { screen }
             })
         }

--- a/src/ios/display.rs
+++ b/src/ios/display.rs
@@ -4,9 +4,10 @@
 //! and possibly an external display via AirPlay or USB-C.
 
 use anyhow::Result;
-use core_graphics::geometry::CGRect;
 use gpui::{px, size, Bounds, DisplayId, Pixels, PlatformDisplay};
 use objc2::{class, msg_send, sel};
+
+use super::cg_types::ObjcCGRect;
 use uuid::Uuid;
 
 /// Represents an iOS display (UIScreen).
@@ -42,7 +43,7 @@ impl IosDisplay {
     }
 
     /// Get the screen bounds in points.
-    fn bounds_in_points(&self) -> CGRect {
+    fn bounds_in_points(&self) -> ObjcCGRect {
         unsafe { msg_send![self.screen, bounds] }
     }
 
@@ -78,8 +79,8 @@ impl PlatformDisplay for IosDisplay {
         // Create a deterministic UUID from screen properties
         let bytes = format!(
             "ios-screen-{}-{}-{}",
-            bounds.size.width as u32,
-            bounds.size.height as u32,
+            bounds.width as u32,
+            bounds.height as u32,
             (scale * 100.0) as u32
         );
 
@@ -91,7 +92,7 @@ impl PlatformDisplay for IosDisplay {
 
         Bounds {
             origin: Default::default(),
-            size: size(px(bounds.size.width as f32), px(bounds.size.height as f32)),
+            size: size(px(bounds.width as f32), px(bounds.height as f32)),
         }
     }
 }

--- a/src/ios/events.rs
+++ b/src/ios/events.rs
@@ -6,10 +6,11 @@
 //! - Pan gesture → ScrollWheel events
 //! - Touch move → MouseMove events
 
-use core_graphics::geometry::CGPoint;
 use gpui::{px, Pixels, Point, TouchPhase};
 use objc2::runtime::AnyObject;
 use objc2::{msg_send, sel};
+
+use super::cg_types::ObjcCGPoint;
 
 /// Touch phase from UIKit
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -50,7 +51,7 @@ impl From<UITouchPhase> for TouchPhase {
 /// Convert a UITouch to a mouse position
 pub fn touch_location_in_view(touch: *mut AnyObject, view: *mut AnyObject) -> Point<Pixels> {
     unsafe {
-        let location: CGPoint = msg_send![touch, locationInView: view];
+        let location: ObjcCGPoint = msg_send![touch, locationInView: view];
         Point::new(px(location.x as f32), px(location.y as f32))
     }
 }

--- a/src/ios/events.rs
+++ b/src/ios/events.rs
@@ -8,7 +8,8 @@
 
 use core_graphics::geometry::CGPoint;
 use gpui::{px, Pixels, Point, TouchPhase};
-use objc::{msg_send, runtime::Object, sel, sel_impl};
+use objc2::runtime::AnyObject;
+use objc2::{msg_send, sel};
 
 /// Touch phase from UIKit
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -47,7 +48,7 @@ impl From<UITouchPhase> for TouchPhase {
 }
 
 /// Convert a UITouch to a mouse position
-pub fn touch_location_in_view(touch: *mut Object, view: *mut Object) -> Point<Pixels> {
+pub fn touch_location_in_view(touch: *mut AnyObject, view: *mut AnyObject) -> Point<Pixels> {
     unsafe {
         let location: CGPoint = msg_send![touch, locationInView: view];
         Point::new(px(location.x as f32), px(location.y as f32))
@@ -55,7 +56,7 @@ pub fn touch_location_in_view(touch: *mut Object, view: *mut Object) -> Point<Pi
 }
 
 /// Get the touch phase from a UITouch
-pub fn touch_phase(touch: *mut Object) -> UITouchPhase {
+pub fn touch_phase(touch: *mut AnyObject) -> UITouchPhase {
     unsafe {
         let phase: i64 = msg_send![touch, phase];
         UITouchPhase::from(phase)
@@ -63,7 +64,7 @@ pub fn touch_phase(touch: *mut Object) -> UITouchPhase {
 }
 
 /// Get the number of taps for a touch (for detecting double-tap, etc.)
-pub fn touch_tap_count(touch: *mut Object) -> u32 {
+pub fn touch_tap_count(touch: *mut AnyObject) -> u32 {
     unsafe {
         let count: i64 = msg_send![touch, tapCount];
         count as u32

--- a/src/ios/ffi.rs
+++ b/src/ios/ffi.rs
@@ -271,8 +271,8 @@ pub extern "C" fn gpui_ios_handle_touch(
     // Cast to IosWindow and forward the touch event
     let window = unsafe { &*(window_ptr as *const super::window::IosWindow) };
     window.handle_touch(
-        touch_ptr as *mut objc::runtime::Object,
-        event_ptr as *mut objc::runtime::Object,
+        touch_ptr as *mut objc2::runtime::AnyObject,
+        event_ptr as *mut objc2::runtime::AnyObject,
     );
 }
 
@@ -361,7 +361,7 @@ pub extern "C" fn gpui_ios_handle_text_input(window_ptr: *mut c_void, text_ptr: 
     log::info!("GPUI iOS: Handle text input");
 
     let window = unsafe { &*(window_ptr as *const super::window::IosWindow) };
-    window.handle_text_input(text_ptr as *mut objc::runtime::Object);
+    window.handle_text_input(text_ptr as *mut objc2::runtime::AnyObject);
 }
 
 /// Handle a key event from an external keyboard.
@@ -404,8 +404,8 @@ pub extern "C" fn gpui_ios_handle_open_url(url_ptr: *mut c_void) {
     }
 
     let url_string = unsafe {
-        use objc::{msg_send, sel, sel_impl};
-        let ns_str = url_ptr as *mut objc::runtime::Object;
+        use objc2::{msg_send, sel};
+        let ns_str = url_ptr as *mut objc2::runtime::AnyObject;
         let cstr: *const std::ffi::c_char = msg_send![ns_str, UTF8String];
         if cstr.is_null() {
             return;

--- a/src/ios/mod.rs
+++ b/src/ios/mod.rs
@@ -7,6 +7,7 @@
 //! - Metal for GPU rendering
 //! - CoreFoundation for many utilities
 
+pub(crate) mod cg_types;
 mod dispatcher;
 mod display;
 mod events;

--- a/src/ios/mod.rs
+++ b/src/ios/mod.rs
@@ -16,6 +16,7 @@ mod platform;
 pub mod platform_view;
 mod text_input;
 mod text_system;
+pub mod util;
 mod window;
 
 pub(crate) use dispatcher::*;

--- a/src/ios/platform.rs
+++ b/src/ios/platform.rs
@@ -17,7 +17,8 @@ use gpui::{
     PlatformKeyboardLayout, PlatformKeyboardMapper, PlatformTextSystem, PlatformWindow, Result,
     Task, ThermalState, WindowAppearance, WindowParams,
 };
-use objc::{class, msg_send, runtime::Object, sel, sel_impl};
+use objc2::runtime::AnyObject;
+use objc2::{class, msg_send, sel};
 use parking_lot::Mutex;
 use std::{
     path::{Path, PathBuf},
@@ -169,12 +170,12 @@ impl Platform for IosPlatform {
     fn window_appearance(&self) -> WindowAppearance {
         unsafe {
             let style: i64 = {
-                let app: *mut Object = msg_send![class!(UIApplication), sharedApplication];
-                let key_window: *mut Object = msg_send![app, keyWindow];
+                let app: *mut AnyObject = msg_send![class!(UIApplication), sharedApplication];
+                let key_window: *mut AnyObject = msg_send![app, keyWindow];
                 if key_window.is_null() {
                     return WindowAppearance::Light;
                 }
-                let trait_collection: *mut Object = msg_send![key_window, traitCollection];
+                let trait_collection: *mut AnyObject = msg_send![key_window, traitCollection];
                 msg_send![trait_collection, userInterfaceStyle]
             };
 
@@ -188,11 +189,11 @@ impl Platform for IosPlatform {
 
     fn open_url(&self, url: &str) {
         unsafe {
-            let url_string: *mut Object =
+            let url_string: *mut AnyObject =
                 msg_send![class!(NSString), stringWithUTF8String: url.as_ptr()];
-            let url: *mut Object = msg_send![class!(NSURL), URLWithString: url_string];
-            let app: *mut Object = msg_send![class!(UIApplication), sharedApplication];
-            let _: () = msg_send![app, openURL: url options: std::ptr::null::<Object>() completionHandler: std::ptr::null::<Object>()];
+            let url: *mut AnyObject = msg_send![class!(NSURL), URLWithString: url_string];
+            let app: *mut AnyObject = msg_send![class!(UIApplication), sharedApplication];
+            let _: () = msg_send![app, openURL: url options: std::ptr::null::<AnyObject>() completionHandler: std::ptr::null::<AnyObject>()];
         }
     }
 
@@ -269,8 +270,8 @@ impl Platform for IosPlatform {
 
     fn app_path(&self) -> Result<PathBuf> {
         unsafe {
-            let bundle: *mut Object = msg_send![class!(NSBundle), mainBundle];
-            let path: *mut Object = msg_send![bundle, bundlePath];
+            let bundle: *mut AnyObject = msg_send![class!(NSBundle), mainBundle];
+            let path: *mut AnyObject = msg_send![bundle, bundlePath];
             let utf8: *const i8 = msg_send![path, UTF8String];
             if utf8.is_null() {
                 return Err(anyhow!("Failed to get bundle path"));
@@ -295,9 +296,9 @@ impl Platform for IosPlatform {
 
     fn write_to_clipboard(&self, item: ClipboardItem) {
         unsafe {
-            let pasteboard: *mut Object = msg_send![class!(UIPasteboard), generalPasteboard];
+            let pasteboard: *mut AnyObject = msg_send![class!(UIPasteboard), generalPasteboard];
             if let Some(text) = item.text() {
-                let ns_string: *mut Object =
+                let ns_string: *mut AnyObject =
                     msg_send![class!(NSString), stringWithUTF8String: text.as_ptr()];
                 let _: () = msg_send![pasteboard, setString: ns_string];
             }
@@ -306,8 +307,8 @@ impl Platform for IosPlatform {
 
     fn read_from_clipboard(&self) -> Option<ClipboardItem> {
         unsafe {
-            let pasteboard: *mut Object = msg_send![class!(UIPasteboard), generalPasteboard];
-            let string: *mut Object = msg_send![pasteboard, string];
+            let pasteboard: *mut AnyObject = msg_send![class!(UIPasteboard), generalPasteboard];
+            let string: *mut AnyObject = msg_send![pasteboard, string];
             if string.is_null() {
                 return None;
             }

--- a/src/ios/platform_view.rs
+++ b/src/ios/platform_view.rs
@@ -14,6 +14,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use objc2::runtime::AnyObject;
 use objc2::{class, msg_send, sel};
 
+#[cfg(target_os = "ios")]
+use super::cg_types::ObjcCGRect;
+
 /// iOS implementation of a platform view.
 ///
 /// Wraps a `UIView` instance. The view is created during construction but
@@ -77,9 +80,11 @@ impl IosPlatformView {
         params: &PlatformViewParams,
     ) -> Result<*mut AnyObject, String> {
         unsafe {
-            let frame = core_graphics::geometry::CGRect::new(
-                &core_graphics::geometry::CGPoint::new(bounds.x as f64, bounds.y as f64),
-                &core_graphics::geometry::CGSize::new(bounds.width as f64, bounds.height as f64),
+            let frame = ObjcCGRect::new(
+                bounds.x as f64,
+                bounds.y as f64,
+                bounds.width as f64,
+                bounds.height as f64,
             );
 
             let view: *mut AnyObject = match view_type {
@@ -112,7 +117,7 @@ impl IosPlatformView {
     /// Create a generic transparent UIView container.
     #[cfg(target_os = "ios")]
     unsafe fn create_generic_view(
-        frame: core_graphics::geometry::CGRect,
+        frame: ObjcCGRect,
     ) -> Result<*mut AnyObject, String> {
         let uiview_class = class!(UIView);
         let view: *mut AnyObject = msg_send![uiview_class, alloc];
@@ -128,7 +133,7 @@ impl IosPlatformView {
     /// Create a UIView with an AVPlayerLayer for video playback.
     #[cfg(target_os = "ios")]
     unsafe fn create_video_player_view(
-        frame: core_graphics::geometry::CGRect,
+        frame: ObjcCGRect,
         params: &PlatformViewParams,
     ) -> Result<*mut AnyObject, String> {
         // Create a container UIView
@@ -168,7 +173,7 @@ impl IosPlatformView {
     /// Create a WKWebView.
     #[cfg(target_os = "ios")]
     unsafe fn create_webview_view(
-        frame: core_graphics::geometry::CGRect,
+        frame: ObjcCGRect,
         params: &PlatformViewParams,
     ) -> Result<*mut AnyObject, String> {
         let config: *mut AnyObject = msg_send![class!(WKWebViewConfiguration), alloc];
@@ -221,7 +226,7 @@ impl IosPlatformView {
     /// Create a UIView with AVCaptureVideoPreviewLayer for camera preview.
     #[cfg(target_os = "ios")]
     unsafe fn create_camera_preview_view(
-        frame: core_graphics::geometry::CGRect,
+        frame: ObjcCGRect,
         params: &PlatformViewParams,
     ) -> Result<*mut AnyObject, String> {
         let uiview_class = class!(UIView);
@@ -341,9 +346,11 @@ impl IosPlatformView {
             return;
         }
         unsafe {
-            let frame = core_graphics::geometry::CGRect::new(
-                &core_graphics::geometry::CGPoint::new(bounds.x as f64, bounds.y as f64),
-                &core_graphics::geometry::CGSize::new(bounds.width as f64, bounds.height as f64),
+            let frame = ObjcCGRect::new(
+                bounds.x as f64,
+                bounds.y as f64,
+                bounds.width as f64,
+                bounds.height as f64,
             );
             let _: () = msg_send![view, setFrame: frame];
         }

--- a/src/ios/platform_view.rs
+++ b/src/ios/platform_view.rs
@@ -261,15 +261,9 @@ impl IosPlatformView {
         Ok(view)
     }
 
-    /// Create a retained NSString from a Rust `&str`.
     #[cfg(target_os = "ios")]
     unsafe fn make_nsstring(s: &str) -> *mut AnyObject {
-        let nsstring_class = class!(NSString);
-        let bytes = s.as_ptr();
-        let len = s.len();
-        let obj: *mut AnyObject = msg_send![nsstring_class, alloc];
-        let obj: *mut AnyObject = msg_send![obj, initWithBytes:bytes length:len encoding:4u64];
-        obj
+        crate::ios::util::nsstring(s)
     }
 
     /// Returns the raw pointer to the underlying `UIView`.

--- a/src/ios/platform_view.rs
+++ b/src/ios/platform_view.rs
@@ -11,13 +11,14 @@ use crate::platform_view::{
 use std::sync::atomic::{AtomicBool, Ordering};
 
 #[cfg(target_os = "ios")]
-use objc::{class, msg_send, runtime::Object, sel, sel_impl};
+use objc2::runtime::AnyObject;
+use objc2::{class, msg_send, sel};
 
 /// iOS implementation of a platform view.
 ///
 /// Wraps a `UIView` instance. The view is created during construction but
 /// is NOT automatically added to the view hierarchy. Call
-/// `native_view_ptr()` to get the raw `*mut Object` pointer, then insert
+/// `native_view_ptr()` to get the raw `*mut AnyObject` pointer, then insert
 /// it into the appropriate superview from the iOS window code.
 ///
 /// TODO: The window/paint code should call `native_view_ptr()` and insert
@@ -29,7 +30,7 @@ pub struct IosPlatformView {
     /// Pointer to the Objective-C UIView instance.
     /// Null if disposed.
     #[cfg(target_os = "ios")]
-    native_view: std::sync::Mutex<*mut Object>,
+    native_view: std::sync::Mutex<*mut AnyObject>,
     disposed: AtomicBool,
     /// Whether this view has been inserted into the window's view hierarchy.
     inserted: AtomicBool,
@@ -74,14 +75,14 @@ impl IosPlatformView {
         view_type: &str,
         bounds: &PlatformViewBounds,
         params: &PlatformViewParams,
-    ) -> Result<*mut Object, String> {
+    ) -> Result<*mut AnyObject, String> {
         unsafe {
             let frame = core_graphics::geometry::CGRect::new(
                 &core_graphics::geometry::CGPoint::new(bounds.x as f64, bounds.y as f64),
                 &core_graphics::geometry::CGSize::new(bounds.width as f64, bounds.height as f64),
             );
 
-            let view: *mut Object = match view_type {
+            let view: *mut AnyObject = match view_type {
                 "video_player" => Self::create_video_player_view(frame, params)?,
                 "webview" => Self::create_webview_view(frame, params)?,
                 "camera_preview" => Self::create_camera_preview_view(frame, params)?,
@@ -112,14 +113,14 @@ impl IosPlatformView {
     #[cfg(target_os = "ios")]
     unsafe fn create_generic_view(
         frame: core_graphics::geometry::CGRect,
-    ) -> Result<*mut Object, String> {
+    ) -> Result<*mut AnyObject, String> {
         let uiview_class = class!(UIView);
-        let view: *mut Object = msg_send![uiview_class, alloc];
-        let view: *mut Object = msg_send![view, initWithFrame: frame];
+        let view: *mut AnyObject = msg_send![uiview_class, alloc];
+        let view: *mut AnyObject = msg_send![view, initWithFrame: frame];
         if view.is_null() {
             return Err("Failed to create UIView".into());
         }
-        let clear_color: *mut Object = msg_send![class!(UIColor), clearColor];
+        let clear_color: *mut AnyObject = msg_send![class!(UIColor), clearColor];
         let _: () = msg_send![view, setBackgroundColor: clear_color];
         Ok(view)
     }
@@ -129,16 +130,16 @@ impl IosPlatformView {
     unsafe fn create_video_player_view(
         frame: core_graphics::geometry::CGRect,
         params: &PlatformViewParams,
-    ) -> Result<*mut Object, String> {
+    ) -> Result<*mut AnyObject, String> {
         // Create a container UIView
         let uiview_class = class!(UIView);
-        let view: *mut Object = msg_send![uiview_class, alloc];
-        let view: *mut Object = msg_send![view, initWithFrame: frame];
+        let view: *mut AnyObject = msg_send![uiview_class, alloc];
+        let view: *mut AnyObject = msg_send![view, initWithFrame: frame];
         if view.is_null() {
             return Err("Failed to create UIView for video_player".into());
         }
 
-        let black_color: *mut Object = msg_send![class!(UIColor), blackColor];
+        let black_color: *mut AnyObject = msg_send![class!(UIColor), blackColor];
         let _: () = msg_send![view, setBackgroundColor: black_color];
 
         // If a player_id is provided, try to get the AVPlayer and create AVPlayerLayer
@@ -146,7 +147,7 @@ impl IosPlatformView {
             if let Ok(player_id) = player_id_str.parse::<u32>() {
                 // Get AVPlayer from the video_player package's PLAYERS map
                 if let Some(player_ptr) = crate::packages::video_player::ios_get_player(player_id) {
-                    let player_layer: *mut Object =
+                    let player_layer: *mut AnyObject =
                         msg_send![class!(AVPlayerLayer), playerLayerWithPlayer: player_ptr];
                     if !player_layer.is_null() {
                         let _: () = msg_send![player_layer, setFrame: frame];
@@ -154,7 +155,7 @@ impl IosPlatformView {
                         let gravity = Self::make_nsstring("AVLayerVideoGravityResizeAspect");
                         let _: () = msg_send![player_layer, setVideoGravity: gravity];
                         let _: () = msg_send![gravity, release];
-                        let view_layer: *mut Object = msg_send![view, layer];
+                        let view_layer: *mut AnyObject = msg_send![view, layer];
                         let _: () = msg_send![view_layer, addSublayer: player_layer];
                     }
                 }
@@ -169,9 +170,9 @@ impl IosPlatformView {
     unsafe fn create_webview_view(
         frame: core_graphics::geometry::CGRect,
         params: &PlatformViewParams,
-    ) -> Result<*mut Object, String> {
-        let config: *mut Object = msg_send![class!(WKWebViewConfiguration), alloc];
-        let config: *mut Object = msg_send![config, init];
+    ) -> Result<*mut AnyObject, String> {
+        let config: *mut AnyObject = msg_send![class!(WKWebViewConfiguration), alloc];
+        let config: *mut AnyObject = msg_send![config, init];
         if config.is_null() {
             return Err("Failed to create WKWebViewConfiguration".into());
         }
@@ -182,13 +183,13 @@ impl IosPlatformView {
             .map(|v| v == "true")
             .unwrap_or(true);
 
-        let prefs: *mut Object = msg_send![config, preferences];
+        let prefs: *mut AnyObject = msg_send![config, preferences];
         if !prefs.is_null() {
             let _: () = msg_send![prefs, setJavaScriptEnabled: js_enabled];
         }
 
-        let webview: *mut Object = msg_send![class!(WKWebView), alloc];
-        let webview: *mut Object = msg_send![webview, initWithFrame: frame configuration: config];
+        let webview: *mut AnyObject = msg_send![class!(WKWebView), alloc];
+        let webview: *mut AnyObject = msg_send![webview, initWithFrame: frame configuration: config];
         if webview.is_null() {
             return Err("Failed to create WKWebView".into());
         }
@@ -197,19 +198,19 @@ impl IosPlatformView {
         if let Some(url) = params.creation_params.get("url") {
             if !url.is_empty() {
                 let ns_url_str = Self::make_nsstring(url);
-                let nsurl: *mut Object = msg_send![class!(NSURL), URLWithString: ns_url_str];
+                let nsurl: *mut AnyObject = msg_send![class!(NSURL), URLWithString: ns_url_str];
                 if !nsurl.is_null() {
-                    let request: *mut Object =
+                    let request: *mut AnyObject =
                         msg_send![class!(NSURLRequest), requestWithURL: nsurl];
-                    let _: *mut Object = msg_send![webview, loadRequest: request];
+                    let _: *mut AnyObject = msg_send![webview, loadRequest: request];
                 }
                 let _: () = msg_send![ns_url_str, release];
             }
         } else if let Some(html) = params.creation_params.get("html") {
             if !html.is_empty() {
                 let ns_html = Self::make_nsstring(html);
-                let base_url: *mut Object = std::ptr::null_mut();
-                let _: *mut Object = msg_send![webview, loadHTMLString: ns_html baseURL: base_url];
+                let base_url: *mut AnyObject = std::ptr::null_mut();
+                let _: *mut AnyObject = msg_send![webview, loadHTMLString: ns_html baseURL: base_url];
                 let _: () = msg_send![ns_html, release];
             }
         }
@@ -222,29 +223,29 @@ impl IosPlatformView {
     unsafe fn create_camera_preview_view(
         frame: core_graphics::geometry::CGRect,
         params: &PlatformViewParams,
-    ) -> Result<*mut Object, String> {
+    ) -> Result<*mut AnyObject, String> {
         let uiview_class = class!(UIView);
-        let view: *mut Object = msg_send![uiview_class, alloc];
-        let view: *mut Object = msg_send![view, initWithFrame: frame];
+        let view: *mut AnyObject = msg_send![uiview_class, alloc];
+        let view: *mut AnyObject = msg_send![view, initWithFrame: frame];
         if view.is_null() {
             return Err("Failed to create UIView for camera_preview".into());
         }
 
-        let black_color: *mut Object = msg_send![class!(UIColor), blackColor];
+        let black_color: *mut AnyObject = msg_send![class!(UIColor), blackColor];
         let _: () = msg_send![view, setBackgroundColor: black_color];
 
         // If a session_id is provided, try to get the AVCaptureSession and create preview layer
         if let Some(session_id_str) = params.creation_params.get("session_id") {
             if let Ok(session_id) = session_id_str.parse::<usize>() {
                 if let Some(session_ptr) = crate::packages::camera::ios_get_session(session_id) {
-                    let layer: *mut Object = msg_send![class!(AVCaptureVideoPreviewLayer), alloc];
-                    let layer: *mut Object = msg_send![layer, initWithSession: session_ptr];
+                    let layer: *mut AnyObject = msg_send![class!(AVCaptureVideoPreviewLayer), alloc];
+                    let layer: *mut AnyObject = msg_send![layer, initWithSession: session_ptr];
                     if !layer.is_null() {
                         let _: () = msg_send![layer, setFrame: frame];
                         let gravity = Self::make_nsstring("AVLayerVideoGravityResizeAspectFill");
                         let _: () = msg_send![layer, setVideoGravity: gravity];
                         let _: () = msg_send![gravity, release];
-                        let view_layer: *mut Object = msg_send![view, layer];
+                        let view_layer: *mut AnyObject = msg_send![view, layer];
                         let _: () = msg_send![view_layer, addSublayer: layer];
                     }
                 }
@@ -256,12 +257,12 @@ impl IosPlatformView {
 
     /// Create a retained NSString from a Rust `&str`.
     #[cfg(target_os = "ios")]
-    unsafe fn make_nsstring(s: &str) -> *mut Object {
+    unsafe fn make_nsstring(s: &str) -> *mut AnyObject {
         let nsstring_class = class!(NSString);
         let bytes = s.as_ptr();
         let len = s.len();
-        let obj: *mut Object = msg_send![nsstring_class, alloc];
-        let obj: *mut Object = msg_send![obj, initWithBytes:bytes length:len encoding:4u64];
+        let obj: *mut AnyObject = msg_send![nsstring_class, alloc];
+        let obj: *mut AnyObject = msg_send![obj, initWithBytes:bytes length:len encoding:4u64];
         obj
     }
 
@@ -270,7 +271,7 @@ impl IosPlatformView {
     /// Use this to insert the view into the iOS view hierarchy from
     /// the window/paint code. Returns null if the view has been disposed.
     #[cfg(target_os = "ios")]
-    pub fn native_view_ptr(&self) -> *mut Object {
+    pub fn native_view_ptr(&self) -> *mut AnyObject {
         *self.native_view.lock().unwrap()
     }
 
@@ -302,8 +303,8 @@ impl IosPlatformView {
                     if !window_ptr.is_null() {
                         let window = &*window_ptr;
                         // Get the view controller's view (parent of Metal view)
-                        let vc: *mut Object = window.view_controller_ptr();
-                        let vc_view: *mut Object = msg_send![vc, view];
+                        let vc: *mut AnyObject = window.view_controller_ptr();
+                        let vc_view: *mut AnyObject = msg_send![vc, view];
                         if !vc_view.is_null() {
                             // Get the Metal view
                             let metal_view = window.metal_view_ptr();
@@ -395,7 +396,7 @@ impl PlatformView for IosPlatformView {
             let view = *self.native_view.lock().unwrap();
             if !view.is_null() {
                 unsafe {
-                    let layer: *mut Object = msg_send![view, layer];
+                    let layer: *mut AnyObject = msg_send![view, layer];
                     if !layer.is_null() {
                         let z = z_index as f64;
                         let _: () = msg_send![layer, setZPosition: z];

--- a/src/ios/platform_view.rs
+++ b/src/ios/platform_view.rs
@@ -116,9 +116,7 @@ impl IosPlatformView {
 
     /// Create a generic transparent UIView container.
     #[cfg(target_os = "ios")]
-    unsafe fn create_generic_view(
-        frame: ObjcCGRect,
-    ) -> Result<*mut AnyObject, String> {
+    unsafe fn create_generic_view(frame: ObjcCGRect) -> Result<*mut AnyObject, String> {
         let uiview_class = class!(UIView);
         let view: *mut AnyObject = msg_send![uiview_class, alloc];
         let view: *mut AnyObject = msg_send![view, initWithFrame: frame];
@@ -194,7 +192,8 @@ impl IosPlatformView {
         }
 
         let webview: *mut AnyObject = msg_send![class!(WKWebView), alloc];
-        let webview: *mut AnyObject = msg_send![webview, initWithFrame: frame configuration: config];
+        let webview: *mut AnyObject =
+            msg_send![webview, initWithFrame: frame configuration: config];
         if webview.is_null() {
             return Err("Failed to create WKWebView".into());
         }
@@ -215,7 +214,8 @@ impl IosPlatformView {
             if !html.is_empty() {
                 let ns_html = Self::make_nsstring(html);
                 let base_url: *mut AnyObject = std::ptr::null_mut();
-                let _: *mut AnyObject = msg_send![webview, loadHTMLString: ns_html baseURL: base_url];
+                let _: *mut AnyObject =
+                    msg_send![webview, loadHTMLString: ns_html baseURL: base_url];
                 let _: () = msg_send![ns_html, release];
             }
         }
@@ -243,7 +243,8 @@ impl IosPlatformView {
         if let Some(session_id_str) = params.creation_params.get("session_id") {
             if let Ok(session_id) = session_id_str.parse::<usize>() {
                 if let Some(session_ptr) = crate::packages::camera::ios_get_session(session_id) {
-                    let layer: *mut AnyObject = msg_send![class!(AVCaptureVideoPreviewLayer), alloc];
+                    let layer: *mut AnyObject =
+                        msg_send![class!(AVCaptureVideoPreviewLayer), alloc];
                     let layer: *mut AnyObject = msg_send![layer, initWithSession: session_ptr];
                     if !layer.is_null() {
                         let _: () = msg_send![layer, setFrame: frame];

--- a/src/ios/util.rs
+++ b/src/ios/util.rs
@@ -1,0 +1,23 @@
+//! Shared iOS utility helpers.
+
+use objc2::runtime::AnyObject;
+use objc2::{class, msg_send};
+
+/// Create an autoreleased `NSString` from a Rust `&str`.
+///
+/// Uses `alloc + initWithBytes:length:encoding:` (NSUTF8StringEncoding = 4)
+/// followed by `autorelease`, so callers never need to manually `release` the
+/// returned pointer.
+///
+/// # Safety
+/// Must be called from an Objective-C thread that has an active autorelease
+/// pool (guaranteed by any UIKit entry-point or GCD-dispatched block).
+pub unsafe fn nsstring(s: &str) -> *mut AnyObject {
+    let ns: *mut AnyObject = msg_send![class!(NSString), alloc];
+    let ns: *mut AnyObject = msg_send![ns,
+        initWithBytes: s.as_ptr() as *const std::ffi::c_void
+        length: s.len()
+        encoding: 4u64 // NSUTF8StringEncoding
+    ];
+    msg_send![ns, autorelease]
+}

--- a/src/ios/window.rs
+++ b/src/ios/window.rs
@@ -21,9 +21,12 @@ use gpui::{
     WindowBackgroundAppearance, WindowBounds, WindowControlArea, WindowParams,
 };
 use gpui_wgpu::{GpuContext, WgpuContext, WgpuRenderer, WgpuSurfaceConfig};
+use objc2::encode::{Encode, Encoding, RefEncode};
 use objc2::ffi::{BOOL, YES};
 use objc2::runtime::{AnyClass, AnyObject, ClassBuilder, Sel};
 use objc2::{class, msg_send, sel};
+
+use super::cg_types::ObjcCGRect;
 use parking_lot::Mutex;
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle, UiKitDisplayHandle, UiKitWindowHandle};
 use std::{
@@ -83,10 +86,10 @@ static STATUS_BAR_STYLE: std::sync::atomic::AtomicI32 = std::sync::atomic::Atomi
 fn register_view_controller_class() -> &'static AnyClass {
     VC_CLASS_REGISTERED.call_once(|| {
         let superclass = class!(UIViewController);
-        let mut decl = ClassBuilder::new("GPUIViewController", superclass).unwrap();
+        let mut decl = ClassBuilder::new(c"GPUIViewController", superclass).unwrap();
 
         // Override preferredStatusBarStyle
-        extern "C" fn preferred_status_bar_style(_this: &AnyObject, _sel: Sel) -> isize {
+        extern "C" fn preferred_status_bar_style(_this: *mut AnyObject, _sel: Sel) -> isize {
             let style = STATUS_BAR_STYLE.load(std::sync::atomic::Ordering::Relaxed);
             if style == 1 {
                 1 // UIStatusBarStyleLightContent
@@ -97,11 +100,11 @@ fn register_view_controller_class() -> &'static AnyClass {
 
         // Override viewDidLayoutSubviews — called by UIKit on rotation,
         // split-screen changes, and any other layout pass.
-        extern "C" fn view_did_layout_subviews(this: &AnyObject, _sel: Sel) {
+        extern "C" fn view_did_layout_subviews(this: *mut AnyObject, _sel: Sel) {
             // Call super
             unsafe {
                 let superclass = class!(UIViewController);
-                let _: () = msg_send![super(this, superclass), viewDidLayoutSubviews];
+                let _: () = msg_send![super(&*this, superclass), viewDidLayoutSubviews];
             }
 
             // Notify all registered GPUI windows about the layout change.
@@ -121,11 +124,11 @@ fn register_view_controller_class() -> &'static AnyClass {
         unsafe {
             decl.add_method(
                 sel!(preferredStatusBarStyle),
-                preferred_status_bar_style as extern "C" fn(&AnyObject, Sel) -> isize,
+                preferred_status_bar_style as extern "C" fn(*mut AnyObject, Sel) -> isize,
             );
             decl.add_method(
                 sel!(viewDidLayoutSubviews),
-                view_did_layout_subviews as extern "C" fn(&AnyObject, Sel),
+                view_did_layout_subviews as extern "C" fn(*mut AnyObject, Sel),
             );
         }
 
@@ -170,19 +173,19 @@ pub fn set_status_bar_style(style: crate::StatusBarContentStyle) {
 fn register_metal_view_class() -> &'static AnyClass {
     METAL_VIEW_CLASS_REGISTERED.call_once(|| {
         let superclass = class!(UIView);
-        let mut decl = ClassBuilder::new("GPUIMetalView", superclass).unwrap();
+        let mut decl = ClassBuilder::new(c"GPUIMetalView", superclass).unwrap();
 
         // Add ivar to store window pointer for touch handling
-        decl.add_ivar::<*mut std::ffi::c_void>(GPUI_WINDOW_IVAR);
+        decl.add_ivar::<*mut std::ffi::c_void>(c"gpui_window_ptr");
 
         // Override layerClass to return CAMetalLayer
-        extern "C" fn layer_class(_self: &AnyClass, _sel: Sel) -> *const AnyClass {
+        extern "C" fn layer_class(_self: *const AnyClass, _sel: Sel) -> *const AnyClass {
             class!(CAMetalLayer) as *const AnyClass
         }
 
         // Touch handling methods
         extern "C" fn touches_began(
-            this: &mut AnyObject,
+            this: *mut AnyObject,
             _sel: Sel,
             touches: *mut AnyObject,
             event: *mut AnyObject,
@@ -191,7 +194,7 @@ fn register_metal_view_class() -> &'static AnyClass {
         }
 
         extern "C" fn touches_moved(
-            this: &mut AnyObject,
+            this: *mut AnyObject,
             _sel: Sel,
             touches: *mut AnyObject,
             event: *mut AnyObject,
@@ -200,7 +203,7 @@ fn register_metal_view_class() -> &'static AnyClass {
         }
 
         extern "C" fn touches_ended(
-            this: &mut AnyObject,
+            this: *mut AnyObject,
             _sel: Sel,
             touches: *mut AnyObject,
             event: *mut AnyObject,
@@ -209,7 +212,7 @@ fn register_metal_view_class() -> &'static AnyClass {
         }
 
         extern "C" fn touches_cancelled(
-            this: &mut AnyObject,
+            this: *mut AnyObject,
             _sel: Sel,
             touches: *mut AnyObject,
             event: *mut AnyObject,
@@ -221,25 +224,25 @@ fn register_metal_view_class() -> &'static AnyClass {
             // Add class method for layerClass
             decl.add_class_method(
                 sel!(layerClass),
-                layer_class as extern "C" fn(&AnyClass, Sel) -> *const AnyClass,
+                layer_class as extern "C" fn(*const AnyClass, Sel) -> *const AnyClass,
             );
 
             // Add touch handling instance methods
             decl.add_method(
                 sel!(touchesBegan:withEvent:),
-                touches_began as extern "C" fn(&mut AnyObject, Sel, *mut AnyObject, *mut AnyObject),
+                touches_began as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject, *mut AnyObject),
             );
             decl.add_method(
                 sel!(touchesMoved:withEvent:),
-                touches_moved as extern "C" fn(&mut AnyObject, Sel, *mut AnyObject, *mut AnyObject),
+                touches_moved as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject, *mut AnyObject),
             );
             decl.add_method(
                 sel!(touchesEnded:withEvent:),
-                touches_ended as extern "C" fn(&mut AnyObject, Sel, *mut AnyObject, *mut AnyObject),
+                touches_ended as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject, *mut AnyObject),
             );
             decl.add_method(
                 sel!(touchesCancelled:withEvent:),
-                touches_cancelled as extern "C" fn(&mut AnyObject, Sel, *mut AnyObject, *mut AnyObject),
+                touches_cancelled as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject, *mut AnyObject),
             );
         }
 
@@ -263,127 +266,117 @@ fn register_metal_view_class() -> &'static AnyClass {
 fn register_text_input_view_class() -> &'static AnyClass {
     TEXT_INPUT_VIEW_CLASS_REGISTERED.call_once(|| {
         let superclass = class!(UIView);
-        let mut decl = ClassBuilder::new("GPUITextInputView", superclass).unwrap();
+        let mut decl = ClassBuilder::new(c"GPUITextInputView", superclass).unwrap();
 
         // Declare protocol conformance so iOS knows this view can receive
         // keyboard text input.
-        if let Some(protocol) = objc2::runtime::AnyProtocol::get("UIKeyInput") {
+        if let Some(protocol) = objc2::runtime::AnyProtocol::get(c"UIKeyInput") {
             decl.add_protocol(protocol);
         }
 
         // Store the IosWindow pointer so callbacks can reach the Rust window.
-        decl.add_ivar::<*mut std::ffi::c_void>(GPUI_WINDOW_IVAR);
+        decl.add_ivar::<*mut std::ffi::c_void>(c"gpui_window_ptr");
 
         // UITextInputTraits property storage — UIView doesn't provide these,
         // but iOS reads them from the first responder to configure the keyboard.
-        decl.add_ivar::<isize>("_keyboardType"); // UIKeyboardType
-        decl.add_ivar::<isize>("_autocorrectionType"); // UITextAutocorrectionType
-        decl.add_ivar::<isize>("_autocapitalizationType"); // UITextAutocapitalizationType
+        decl.add_ivar::<isize>(c"_keyboardType"); // UIKeyboardType
+        decl.add_ivar::<isize>(c"_autocorrectionType"); // UITextAutocorrectionType
+        decl.add_ivar::<isize>(c"_autocapitalizationType"); // UITextAutocapitalizationType
 
         // --- UIKeyInput protocol methods ---
 
         // BOOL hasText
-        extern "C" fn has_text(_this: &AnyObject, _sel: Sel) -> BOOL {
+        unsafe extern "C" fn has_text(_this: *mut AnyObject, _sel: Sel) -> BOOL {
             YES
         }
 
         // void insertText:(NSString *)text
-        extern "C" fn insert_text(this: &AnyObject, _sel: Sel, text: *mut AnyObject) {
-            unsafe {
-                let window_ptr: *mut std::ffi::c_void = *this.get_ivar(GPUI_WINDOW_IVAR);
-                if window_ptr.is_null() || text.is_null() {
-                    return;
-                }
-                let window = &*(window_ptr as *const IosWindow);
-                window.handle_text_input(text);
+        unsafe extern "C" fn insert_text(this: *mut AnyObject, _sel: Sel, text: *mut AnyObject) {
+            let window_ptr: *mut std::ffi::c_void = *(*this).get_ivar(GPUI_WINDOW_IVAR);
+            if window_ptr.is_null() || text.is_null() {
+                return;
             }
+            let window = &*(window_ptr as *const IosWindow);
+            window.handle_text_input(text);
         }
 
         // void deleteBackward
-        extern "C" fn delete_backward(this: &AnyObject, _sel: Sel) {
-            unsafe {
-                let window_ptr: *mut std::ffi::c_void = *this.get_ivar(GPUI_WINDOW_IVAR);
-                if window_ptr.is_null() {
-                    return;
-                }
-                let window = &*(window_ptr as *const IosWindow);
-                window.handle_delete_backward();
+        unsafe extern "C" fn delete_backward(this: *mut AnyObject, _sel: Sel) {
+            let window_ptr: *mut std::ffi::c_void = *(*this).get_ivar(GPUI_WINDOW_IVAR);
+            if window_ptr.is_null() {
+                return;
             }
+            let window = &*(window_ptr as *const IosWindow);
+            window.handle_delete_backward();
         }
 
         // canBecomeFirstResponder must return YES
-        extern "C" fn can_become_first_responder(_this: &AnyObject, _sel: Sel) -> BOOL {
+        unsafe extern "C" fn can_become_first_responder(_this: *mut AnyObject, _sel: Sel) -> BOOL {
             YES
         }
 
         // --- UITextInputTraits property accessors ---
-        extern "C" fn get_keyboard_type(this: &AnyObject, _sel: Sel) -> isize {
-            unsafe { *this.get_ivar::<isize>("_keyboardType") }
+        unsafe extern "C" fn get_keyboard_type(this: *mut AnyObject, _sel: Sel) -> isize {
+            *(*this).get_ivar::<isize>("_keyboardType")
         }
-        extern "C" fn set_keyboard_type(this: &mut AnyObject, _sel: Sel, val: isize) {
-            unsafe {
-                this.set_ivar::<isize>("_keyboardType", val);
-            }
+        unsafe extern "C" fn set_keyboard_type(this: *mut AnyObject, _sel: Sel, val: isize) {
+            *(*this).get_mut_ivar::<isize>("_keyboardType") = val;
         }
-        extern "C" fn get_autocorrection_type(this: &AnyObject, _sel: Sel) -> isize {
-            unsafe { *this.get_ivar::<isize>("_autocorrectionType") }
+        unsafe extern "C" fn get_autocorrection_type(this: *mut AnyObject, _sel: Sel) -> isize {
+            *(*this).get_ivar::<isize>("_autocorrectionType")
         }
-        extern "C" fn set_autocorrection_type(this: &mut AnyObject, _sel: Sel, val: isize) {
-            unsafe {
-                this.set_ivar::<isize>("_autocorrectionType", val);
-            }
+        unsafe extern "C" fn set_autocorrection_type(this: *mut AnyObject, _sel: Sel, val: isize) {
+            *(*this).get_mut_ivar::<isize>("_autocorrectionType") = val;
         }
-        extern "C" fn get_autocapitalization_type(this: &AnyObject, _sel: Sel) -> isize {
-            unsafe { *this.get_ivar::<isize>("_autocapitalizationType") }
+        unsafe extern "C" fn get_autocapitalization_type(this: *mut AnyObject, _sel: Sel) -> isize {
+            *(*this).get_ivar::<isize>("_autocapitalizationType")
         }
-        extern "C" fn set_autocapitalization_type(this: &mut AnyObject, _sel: Sel, val: isize) {
-            unsafe {
-                this.set_ivar::<isize>("_autocapitalizationType", val);
-            }
+        unsafe extern "C" fn set_autocapitalization_type(this: *mut AnyObject, _sel: Sel, val: isize) {
+            *(*this).get_mut_ivar::<isize>("_autocapitalizationType") = val;
         }
 
         unsafe {
             decl.add_method(
                 sel!(hasText),
-                has_text as extern "C" fn(&AnyObject, Sel) -> BOOL,
+                has_text as unsafe extern "C" fn(*mut AnyObject, Sel) -> BOOL,
             );
             decl.add_method(
                 sel!(insertText:),
-                insert_text as extern "C" fn(&AnyObject, Sel, *mut AnyObject),
+                insert_text as unsafe extern "C" fn(*mut AnyObject, Sel, *mut AnyObject),
             );
             decl.add_method(
                 sel!(deleteBackward),
-                delete_backward as extern "C" fn(&AnyObject, Sel),
+                delete_backward as unsafe extern "C" fn(*mut AnyObject, Sel),
             );
             decl.add_method(
                 sel!(canBecomeFirstResponder),
-                can_become_first_responder as extern "C" fn(&AnyObject, Sel) -> BOOL,
+                can_become_first_responder as unsafe extern "C" fn(*mut AnyObject, Sel) -> BOOL,
             );
 
             // UITextInputTraits property methods
             decl.add_method(
                 sel!(keyboardType),
-                get_keyboard_type as extern "C" fn(&AnyObject, Sel) -> isize,
+                get_keyboard_type as unsafe extern "C" fn(*mut AnyObject, Sel) -> isize,
             );
             decl.add_method(
                 sel!(setKeyboardType:),
-                set_keyboard_type as extern "C" fn(&mut AnyObject, Sel, isize),
+                set_keyboard_type as unsafe extern "C" fn(*mut AnyObject, Sel, isize),
             );
             decl.add_method(
                 sel!(autocorrectionType),
-                get_autocorrection_type as extern "C" fn(&AnyObject, Sel) -> isize,
+                get_autocorrection_type as unsafe extern "C" fn(*mut AnyObject, Sel) -> isize,
             );
             decl.add_method(
                 sel!(setAutocorrectionType:),
-                set_autocorrection_type as extern "C" fn(&mut AnyObject, Sel, isize),
+                set_autocorrection_type as unsafe extern "C" fn(*mut AnyObject, Sel, isize),
             );
             decl.add_method(
                 sel!(autocapitalizationType),
-                get_autocapitalization_type as extern "C" fn(&AnyObject, Sel) -> isize,
+                get_autocapitalization_type as unsafe extern "C" fn(*mut AnyObject, Sel) -> isize,
             );
             decl.add_method(
                 sel!(setAutocapitalizationType:),
-                set_autocapitalization_type as extern "C" fn(&mut AnyObject, Sel, isize),
+                set_autocapitalization_type as unsafe extern "C" fn(*mut AnyObject, Sel, isize),
             );
         }
 
@@ -394,10 +387,10 @@ fn register_text_input_view_class() -> &'static AnyClass {
 }
 
 /// Handle touch events from the GPUIMetalView
-fn handle_touches(view: &mut AnyObject, touches: *mut AnyObject, event: *mut AnyObject) {
+fn handle_touches(view: *mut AnyObject, touches: *mut AnyObject, event: *mut AnyObject) {
     unsafe {
         // Get the window pointer from the view's ivar
-        let window_ptr: *mut std::ffi::c_void = *view.get_ivar(GPUI_WINDOW_IVAR);
+        let window_ptr: *mut std::ffi::c_void = *(*view).get_ivar(GPUI_WINDOW_IVAR);
         if window_ptr.is_null() {
             log::warn!("GPUI iOS: Touch event but no window pointer set");
             return;
@@ -507,7 +500,7 @@ impl IosWindow {
         unsafe {
             // Create UIWindow
             let screen_obj: *mut AnyObject = msg_send![class!(UIScreen), mainScreen];
-            let screen_bounds_cg: core_graphics::geometry::CGRect = msg_send![screen_obj, bounds];
+            let screen_bounds_cg: ObjcCGRect = msg_send![screen_obj, bounds];
             let window: *mut AnyObject = msg_send![class!(UIWindow), alloc];
             let window: *mut AnyObject = msg_send![window, initWithFrame: screen_bounds_cg];
 
@@ -550,13 +543,7 @@ impl IosWindow {
             // so iOS actually routes keyboard text to us.
             let text_input_class = register_text_input_view_class();
             let text_input_view: *mut AnyObject = msg_send![text_input_class, alloc];
-            let text_input_frame = core_graphics::geometry::CGRect {
-                origin: core_graphics::geometry::CGPoint { x: 0.0, y: 0.0 },
-                size: core_graphics::geometry::CGSize {
-                    width: 1.0,
-                    height: 1.0,
-                },
-            };
+            let text_input_frame = ObjcCGRect::new(0.0, 0.0, 1.0, 1.0);
             let text_input_view: *mut AnyObject =
                 msg_send![text_input_view, initWithFrame: text_input_frame];
             let _: () = msg_send![text_input_view, setAlpha: 0.01_f64];
@@ -564,8 +551,8 @@ impl IosWindow {
             let _: () = msg_send![view, addSubview: text_input_view];
 
             // --- Initialise the wgpu renderer (Metal backend) ---------------
-            let pixel_w = (screen_bounds_cg.size.width * scale) as i32;
-            let pixel_h = (screen_bounds_cg.size.height * scale) as i32;
+            let pixel_w = (screen_bounds_cg.width * scale) as i32;
+            let pixel_h = (screen_bounds_cg.height * scale) as i32;
 
             let _handle = handle; // consumed but not stored
             let ios_window = Self {
@@ -683,8 +670,8 @@ impl IosWindow {
         // and on the text input view so keyboard input can find us.
         unsafe {
             let window_ptr = self as *const Self as *mut std::ffi::c_void;
-            (*self.view).set_ivar(GPUI_WINDOW_IVAR, window_ptr);
-            (*self.text_input_view).set_ivar(GPUI_WINDOW_IVAR, window_ptr);
+            *(*self.view).get_mut_ivar::<*mut c_void>(GPUI_WINDOW_IVAR) = window_ptr;
+            *(*self.text_input_view).get_mut_ivar::<*mut c_void>(GPUI_WINDOW_IVAR) = window_ptr;
             log::info!(
                 "GPUI iOS: Set window pointer {:p} on view {:p} and text input {:p}",
                 window_ptr,
@@ -720,31 +707,30 @@ impl IosWindow {
 
             // Block that fires when the keyboard appears — extracts the
             // end-frame height and stores it in the global atomic.
-            let show_block = block::ConcreteBlock::new(move |notification: *mut AnyObject| {
+            let show_block = block2::RcBlock::new(move |notification: *mut AnyObject| {
                 if notification.is_null() {
                     return;
                 }
-                let user_info: *mut AnyObject = msg_send![notification, userInfo];
+                let user_info: *mut AnyObject = unsafe { msg_send![notification, userInfo] };
                 if user_info.is_null() {
                     return;
                 }
-                let frame_key = make_nsstring("UIKeyboardFrameEndUserInfoKey");
-                let frame_value: *mut AnyObject = msg_send![user_info, objectForKey: frame_key];
+                let frame_key = unsafe { make_nsstring("UIKeyboardFrameEndUserInfoKey") };
+                let frame_value: *mut AnyObject =
+                    unsafe { msg_send![user_info, objectForKey: frame_key] };
                 if frame_value.is_null() {
                     return;
                 }
-                let frame: core_graphics::geometry::CGRect = msg_send![frame_value, CGRectValue];
-                let height = frame.size.height as f32;
+                let frame: ObjcCGRect = unsafe { msg_send![frame_value, CGRectValue] };
+                let height = frame.height as f32;
                 log::info!("GPUI iOS: Keyboard will show, height={}", height);
                 crate::set_keyboard_height(height);
             });
-            let show_block = show_block.copy();
 
-            let hide_block = block::ConcreteBlock::new(move |_notification: *mut AnyObject| {
+            let hide_block = block2::RcBlock::new(move |_notification: *mut AnyObject| {
                 log::info!("GPUI iOS: Keyboard will hide");
                 crate::set_keyboard_height(0.0);
             });
-            let hide_block = hide_block.copy();
 
             let _: *mut AnyObject = msg_send![notification_center,
                 addObserverForName: show_name
@@ -981,6 +967,17 @@ impl IosWindow {
                 left: f64,
                 bottom: f64,
                 right: f64,
+            }
+
+            unsafe impl Encode for UIEdgeInsets {
+                const ENCODING: Encoding = Encoding::Struct(
+                    "UIEdgeInsets",
+                    &[Encoding::Double, Encoding::Double, Encoding::Double, Encoding::Double],
+                );
+            }
+
+            unsafe impl RefEncode for UIEdgeInsets {
+                const ENCODING_REF: Encoding = Encoding::Pointer(&Self::ENCODING);
             }
 
             let insets: UIEdgeInsets = msg_send![self.view, safeAreaInsets];
@@ -1261,12 +1258,12 @@ impl IosWindow {
     /// reconfigures the Metal layer + wgpu surface, and fires the resize callback.
     pub fn handle_layout_change(&self) {
         unsafe {
-            let view_bounds: core_graphics::geometry::CGRect = msg_send![self.view, bounds];
+            let view_bounds: ObjcCGRect = msg_send![self.view, bounds];
             let screen: *mut AnyObject = msg_send![class!(UIScreen), mainScreen];
             let scale: core_graphics::base::CGFloat = msg_send![screen, scale];
 
-            let new_w = view_bounds.size.width as f32;
-            let new_h = view_bounds.size.height as f32;
+            let new_w = view_bounds.width as f32;
+            let new_h = view_bounds.height as f32;
             let new_scale = scale as f32;
 
             let old_bounds = self.bounds.get();

--- a/src/ios/window.rs
+++ b/src/ios/window.rs
@@ -696,19 +696,8 @@ impl IosWindow {
             let notification_center: *mut AnyObject =
                 msg_send![class!(NSNotificationCenter), defaultCenter];
 
-            // Helper to create an NSString from a Rust &str.
-            fn make_nsstring(s: &str) -> *mut AnyObject {
-                let cls = class!(NSString);
-                let bytes = s.as_ptr() as *const c_void;
-                let len = s.len();
-                unsafe {
-                    let ns: *mut AnyObject = msg_send![cls, alloc];
-                    msg_send![ns, initWithBytes:bytes length:len encoding:4u64] // NSUTF8StringEncoding
-                }
-            }
-
-            let show_name = make_nsstring("UIKeyboardWillShowNotification");
-            let hide_name = make_nsstring("UIKeyboardWillHideNotification");
+            let show_name = crate::ios::util::nsstring("UIKeyboardWillShowNotification");
+            let hide_name = crate::ios::util::nsstring("UIKeyboardWillHideNotification");
 
             // Block that fires when the keyboard appears — extracts the
             // end-frame height and stores it in the global atomic.
@@ -720,12 +709,12 @@ impl IosWindow {
                 if user_info.is_null() {
                     return;
                 }
-                let frame_key = unsafe { make_nsstring("UIKeyboardFrameEndUserInfoKey") };
+                let frame_key =
+                    unsafe { crate::ios::util::nsstring("UIKeyboardFrameEndUserInfoKey") };
                 let frame_value: *mut AnyObject =
                     unsafe { msg_send![user_info, objectForKey: frame_key] };
-                unsafe {
-                    let _: () = msg_send![frame_key, release];
-                }
+                // frame_key is autoreleased by util::nsstring — no manual release needed
+                let _ = frame_key;
                 if frame_value.is_null() {
                     return;
                 }
@@ -746,14 +735,13 @@ impl IosWindow {
                 queue: std::ptr::null::<AnyObject>()
                 usingBlock: &*show_block
             ];
-            let _: () = msg_send![show_name, release];
             let _: *mut AnyObject = msg_send![notification_center,
                 addObserverForName: hide_name
                 object: std::ptr::null::<AnyObject>()
                 queue: std::ptr::null::<AnyObject>()
                 usingBlock: &*hide_block
             ];
-            let _: () = msg_send![hide_name, release];
+            // show_name and hide_name are autoreleased by util::nsstring
 
             // Leak the blocks so they live for the app lifetime.
             std::mem::forget(show_block);

--- a/src/ios/window.rs
+++ b/src/ios/window.rs
@@ -104,7 +104,7 @@ fn register_view_controller_class() -> &'static AnyClass {
             // Call super
             unsafe {
                 let superclass = class!(UIViewController);
-                let _: () = msg_send![super(&*this, superclass), viewDidLayoutSubviews];
+                let _: () = msg_send![super(this, superclass), viewDidLayoutSubviews];
             }
 
             // Notify all registered GPUI windows about the layout change.

--- a/src/ios/window.rs
+++ b/src/ios/window.rs
@@ -21,13 +21,9 @@ use gpui::{
     WindowBackgroundAppearance, WindowBounds, WindowControlArea, WindowParams,
 };
 use gpui_wgpu::{GpuContext, WgpuContext, WgpuRenderer, WgpuSurfaceConfig};
-use objc::{
-    class,
-    declare::ClassDecl,
-    msg_send,
-    runtime::{Class, Object, Sel, BOOL, YES},
-    sel, sel_impl,
-};
+use objc2::ffi::{BOOL, YES};
+use objc2::runtime::{AnyClass, AnyObject, ClassBuilder, Sel};
+use objc2::{class, msg_send, sel};
 use parking_lot::Mutex;
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle, UiKitDisplayHandle, UiKitWindowHandle};
 use std::{
@@ -84,13 +80,13 @@ static STATUS_BAR_STYLE: std::sync::atomic::AtomicI32 = std::sync::atomic::Atomi
 
 /// Register a custom UIViewController subclass that allows overriding
 /// `preferredStatusBarStyle` at runtime.
-fn register_view_controller_class() -> &'static Class {
+fn register_view_controller_class() -> &'static AnyClass {
     VC_CLASS_REGISTERED.call_once(|| {
         let superclass = class!(UIViewController);
-        let mut decl = ClassDecl::new("GPUIViewController", superclass).unwrap();
+        let mut decl = ClassBuilder::new("GPUIViewController", superclass).unwrap();
 
         // Override preferredStatusBarStyle
-        extern "C" fn preferred_status_bar_style(_this: &Object, _sel: Sel) -> isize {
+        extern "C" fn preferred_status_bar_style(_this: &AnyObject, _sel: Sel) -> isize {
             let style = STATUS_BAR_STYLE.load(std::sync::atomic::Ordering::Relaxed);
             if style == 1 {
                 1 // UIStatusBarStyleLightContent
@@ -101,7 +97,7 @@ fn register_view_controller_class() -> &'static Class {
 
         // Override viewDidLayoutSubviews — called by UIKit on rotation,
         // split-screen changes, and any other layout pass.
-        extern "C" fn view_did_layout_subviews(this: &Object, _sel: Sel) {
+        extern "C" fn view_did_layout_subviews(this: &AnyObject, _sel: Sel) {
             // Call super
             unsafe {
                 let superclass = class!(UIViewController);
@@ -125,11 +121,11 @@ fn register_view_controller_class() -> &'static Class {
         unsafe {
             decl.add_method(
                 sel!(preferredStatusBarStyle),
-                preferred_status_bar_style as extern "C" fn(&Object, Sel) -> isize,
+                preferred_status_bar_style as extern "C" fn(&AnyObject, Sel) -> isize,
             );
             decl.add_method(
                 sel!(viewDidLayoutSubviews),
-                view_did_layout_subviews as extern "C" fn(&Object, Sel),
+                view_did_layout_subviews as extern "C" fn(&AnyObject, Sel),
             );
         }
 
@@ -171,52 +167,52 @@ pub fn set_status_bar_style(style: crate::StatusBarContentStyle) {
 
 /// Register a custom UIView subclass that uses CAMetalLayer as its backing layer.
 /// This is required for Metal rendering on iOS.
-fn register_metal_view_class() -> &'static Class {
+fn register_metal_view_class() -> &'static AnyClass {
     METAL_VIEW_CLASS_REGISTERED.call_once(|| {
         let superclass = class!(UIView);
-        let mut decl = ClassDecl::new("GPUIMetalView", superclass).unwrap();
+        let mut decl = ClassBuilder::new("GPUIMetalView", superclass).unwrap();
 
         // Add ivar to store window pointer for touch handling
         decl.add_ivar::<*mut std::ffi::c_void>(GPUI_WINDOW_IVAR);
 
         // Override layerClass to return CAMetalLayer
-        extern "C" fn layer_class(_self: &Class, _sel: Sel) -> *const Class {
-            class!(CAMetalLayer) as *const Class
+        extern "C" fn layer_class(_self: &AnyClass, _sel: Sel) -> *const AnyClass {
+            class!(CAMetalLayer) as *const AnyClass
         }
 
         // Touch handling methods
         extern "C" fn touches_began(
-            this: &mut Object,
+            this: &mut AnyObject,
             _sel: Sel,
-            touches: *mut Object,
-            event: *mut Object,
+            touches: *mut AnyObject,
+            event: *mut AnyObject,
         ) {
             handle_touches(this, touches, event);
         }
 
         extern "C" fn touches_moved(
-            this: &mut Object,
+            this: &mut AnyObject,
             _sel: Sel,
-            touches: *mut Object,
-            event: *mut Object,
+            touches: *mut AnyObject,
+            event: *mut AnyObject,
         ) {
             handle_touches(this, touches, event);
         }
 
         extern "C" fn touches_ended(
-            this: &mut Object,
+            this: &mut AnyObject,
             _sel: Sel,
-            touches: *mut Object,
-            event: *mut Object,
+            touches: *mut AnyObject,
+            event: *mut AnyObject,
         ) {
             handle_touches(this, touches, event);
         }
 
         extern "C" fn touches_cancelled(
-            this: &mut Object,
+            this: &mut AnyObject,
             _sel: Sel,
-            touches: *mut Object,
-            event: *mut Object,
+            touches: *mut AnyObject,
+            event: *mut AnyObject,
         ) {
             handle_touches(this, touches, event);
         }
@@ -225,25 +221,25 @@ fn register_metal_view_class() -> &'static Class {
             // Add class method for layerClass
             decl.add_class_method(
                 sel!(layerClass),
-                layer_class as extern "C" fn(&Class, Sel) -> *const Class,
+                layer_class as extern "C" fn(&AnyClass, Sel) -> *const AnyClass,
             );
 
             // Add touch handling instance methods
             decl.add_method(
                 sel!(touchesBegan:withEvent:),
-                touches_began as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object),
+                touches_began as extern "C" fn(&mut AnyObject, Sel, *mut AnyObject, *mut AnyObject),
             );
             decl.add_method(
                 sel!(touchesMoved:withEvent:),
-                touches_moved as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object),
+                touches_moved as extern "C" fn(&mut AnyObject, Sel, *mut AnyObject, *mut AnyObject),
             );
             decl.add_method(
                 sel!(touchesEnded:withEvent:),
-                touches_ended as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object),
+                touches_ended as extern "C" fn(&mut AnyObject, Sel, *mut AnyObject, *mut AnyObject),
             );
             decl.add_method(
                 sel!(touchesCancelled:withEvent:),
-                touches_cancelled as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object),
+                touches_cancelled as extern "C" fn(&mut AnyObject, Sel, *mut AnyObject, *mut AnyObject),
             );
         }
 
@@ -264,14 +260,14 @@ fn register_metal_view_class() -> &'static Class {
 /// - `hasText` → always returns YES (simplifies things; no harm)
 /// - `insertText:` → forwards the text to `IosWindow::handle_text_input`
 /// - `deleteBackward` → dispatches a backspace via `crate::dispatch_text_input`
-fn register_text_input_view_class() -> &'static Class {
+fn register_text_input_view_class() -> &'static AnyClass {
     TEXT_INPUT_VIEW_CLASS_REGISTERED.call_once(|| {
         let superclass = class!(UIView);
-        let mut decl = ClassDecl::new("GPUITextInputView", superclass).unwrap();
+        let mut decl = ClassBuilder::new("GPUITextInputView", superclass).unwrap();
 
         // Declare protocol conformance so iOS knows this view can receive
         // keyboard text input.
-        if let Some(protocol) = objc::runtime::Protocol::get("UIKeyInput") {
+        if let Some(protocol) = objc2::runtime::AnyProtocol::get("UIKeyInput") {
             decl.add_protocol(protocol);
         }
 
@@ -287,12 +283,12 @@ fn register_text_input_view_class() -> &'static Class {
         // --- UIKeyInput protocol methods ---
 
         // BOOL hasText
-        extern "C" fn has_text(_this: &Object, _sel: Sel) -> BOOL {
+        extern "C" fn has_text(_this: &AnyObject, _sel: Sel) -> BOOL {
             YES
         }
 
         // void insertText:(NSString *)text
-        extern "C" fn insert_text(this: &Object, _sel: Sel, text: *mut Object) {
+        extern "C" fn insert_text(this: &AnyObject, _sel: Sel, text: *mut AnyObject) {
             unsafe {
                 let window_ptr: *mut std::ffi::c_void = *this.get_ivar(GPUI_WINDOW_IVAR);
                 if window_ptr.is_null() || text.is_null() {
@@ -304,7 +300,7 @@ fn register_text_input_view_class() -> &'static Class {
         }
 
         // void deleteBackward
-        extern "C" fn delete_backward(this: &Object, _sel: Sel) {
+        extern "C" fn delete_backward(this: &AnyObject, _sel: Sel) {
             unsafe {
                 let window_ptr: *mut std::ffi::c_void = *this.get_ivar(GPUI_WINDOW_IVAR);
                 if window_ptr.is_null() {
@@ -316,31 +312,31 @@ fn register_text_input_view_class() -> &'static Class {
         }
 
         // canBecomeFirstResponder must return YES
-        extern "C" fn can_become_first_responder(_this: &Object, _sel: Sel) -> BOOL {
+        extern "C" fn can_become_first_responder(_this: &AnyObject, _sel: Sel) -> BOOL {
             YES
         }
 
         // --- UITextInputTraits property accessors ---
-        extern "C" fn get_keyboard_type(this: &Object, _sel: Sel) -> isize {
+        extern "C" fn get_keyboard_type(this: &AnyObject, _sel: Sel) -> isize {
             unsafe { *this.get_ivar::<isize>("_keyboardType") }
         }
-        extern "C" fn set_keyboard_type(this: &mut Object, _sel: Sel, val: isize) {
+        extern "C" fn set_keyboard_type(this: &mut AnyObject, _sel: Sel, val: isize) {
             unsafe {
                 this.set_ivar::<isize>("_keyboardType", val);
             }
         }
-        extern "C" fn get_autocorrection_type(this: &Object, _sel: Sel) -> isize {
+        extern "C" fn get_autocorrection_type(this: &AnyObject, _sel: Sel) -> isize {
             unsafe { *this.get_ivar::<isize>("_autocorrectionType") }
         }
-        extern "C" fn set_autocorrection_type(this: &mut Object, _sel: Sel, val: isize) {
+        extern "C" fn set_autocorrection_type(this: &mut AnyObject, _sel: Sel, val: isize) {
             unsafe {
                 this.set_ivar::<isize>("_autocorrectionType", val);
             }
         }
-        extern "C" fn get_autocapitalization_type(this: &Object, _sel: Sel) -> isize {
+        extern "C" fn get_autocapitalization_type(this: &AnyObject, _sel: Sel) -> isize {
             unsafe { *this.get_ivar::<isize>("_autocapitalizationType") }
         }
-        extern "C" fn set_autocapitalization_type(this: &mut Object, _sel: Sel, val: isize) {
+        extern "C" fn set_autocapitalization_type(this: &mut AnyObject, _sel: Sel, val: isize) {
             unsafe {
                 this.set_ivar::<isize>("_autocapitalizationType", val);
             }
@@ -349,45 +345,45 @@ fn register_text_input_view_class() -> &'static Class {
         unsafe {
             decl.add_method(
                 sel!(hasText),
-                has_text as extern "C" fn(&Object, Sel) -> BOOL,
+                has_text as extern "C" fn(&AnyObject, Sel) -> BOOL,
             );
             decl.add_method(
                 sel!(insertText:),
-                insert_text as extern "C" fn(&Object, Sel, *mut Object),
+                insert_text as extern "C" fn(&AnyObject, Sel, *mut AnyObject),
             );
             decl.add_method(
                 sel!(deleteBackward),
-                delete_backward as extern "C" fn(&Object, Sel),
+                delete_backward as extern "C" fn(&AnyObject, Sel),
             );
             decl.add_method(
                 sel!(canBecomeFirstResponder),
-                can_become_first_responder as extern "C" fn(&Object, Sel) -> BOOL,
+                can_become_first_responder as extern "C" fn(&AnyObject, Sel) -> BOOL,
             );
 
             // UITextInputTraits property methods
             decl.add_method(
                 sel!(keyboardType),
-                get_keyboard_type as extern "C" fn(&Object, Sel) -> isize,
+                get_keyboard_type as extern "C" fn(&AnyObject, Sel) -> isize,
             );
             decl.add_method(
                 sel!(setKeyboardType:),
-                set_keyboard_type as extern "C" fn(&mut Object, Sel, isize),
+                set_keyboard_type as extern "C" fn(&mut AnyObject, Sel, isize),
             );
             decl.add_method(
                 sel!(autocorrectionType),
-                get_autocorrection_type as extern "C" fn(&Object, Sel) -> isize,
+                get_autocorrection_type as extern "C" fn(&AnyObject, Sel) -> isize,
             );
             decl.add_method(
                 sel!(setAutocorrectionType:),
-                set_autocorrection_type as extern "C" fn(&mut Object, Sel, isize),
+                set_autocorrection_type as extern "C" fn(&mut AnyObject, Sel, isize),
             );
             decl.add_method(
                 sel!(autocapitalizationType),
-                get_autocapitalization_type as extern "C" fn(&Object, Sel) -> isize,
+                get_autocapitalization_type as extern "C" fn(&AnyObject, Sel) -> isize,
             );
             decl.add_method(
                 sel!(setAutocapitalizationType:),
-                set_autocapitalization_type as extern "C" fn(&mut Object, Sel, isize),
+                set_autocapitalization_type as extern "C" fn(&mut AnyObject, Sel, isize),
             );
         }
 
@@ -398,7 +394,7 @@ fn register_text_input_view_class() -> &'static Class {
 }
 
 /// Handle touch events from the GPUIMetalView
-fn handle_touches(view: &mut Object, touches: *mut Object, event: *mut Object) {
+fn handle_touches(view: &mut AnyObject, touches: *mut AnyObject, event: *mut AnyObject) {
     unsafe {
         // Get the window pointer from the view's ivar
         let window_ptr: *mut std::ffi::c_void = *view.get_ivar(GPUI_WINDOW_IVAR);
@@ -410,11 +406,11 @@ fn handle_touches(view: &mut Object, touches: *mut Object, event: *mut Object) {
         let window = &*(window_ptr as *const IosWindow);
 
         // Get all touches from the set
-        let all_touches: *mut Object = msg_send![touches, allObjects];
+        let all_touches: *mut AnyObject = msg_send![touches, allObjects];
         let count: usize = msg_send![all_touches, count];
 
         for i in 0..count {
-            let touch: *mut Object = msg_send![all_touches, objectAtIndex: i];
+            let touch: *mut AnyObject = msg_send![all_touches, objectAtIndex: i];
             window.handle_touch(touch, event);
         }
     }
@@ -442,13 +438,13 @@ enum TouchState {
 #[allow(clippy::type_complexity)]
 pub(crate) struct IosWindow {
     /// The UIWindow object
-    window: *mut Object,
+    window: *mut AnyObject,
     /// The UIViewController
-    view_controller: *mut Object,
+    view_controller: *mut AnyObject,
     /// The Metal-backed UIView
-    view: *mut Object,
+    view: *mut AnyObject,
     /// The hidden text input view for keyboard input
-    text_input_view: *mut Object,
+    text_input_view: *mut AnyObject,
     /// Current bounds in pixels
     bounds: Cell<Bounds<Pixels>>,
     /// Scale factor
@@ -510,25 +506,25 @@ impl IosWindow {
 
         unsafe {
             // Create UIWindow
-            let screen_obj: *mut Object = msg_send![class!(UIScreen), mainScreen];
+            let screen_obj: *mut AnyObject = msg_send![class!(UIScreen), mainScreen];
             let screen_bounds_cg: core_graphics::geometry::CGRect = msg_send![screen_obj, bounds];
-            let window: *mut Object = msg_send![class!(UIWindow), alloc];
-            let window: *mut Object = msg_send![window, initWithFrame: screen_bounds_cg];
+            let window: *mut AnyObject = msg_send![class!(UIWindow), alloc];
+            let window: *mut AnyObject = msg_send![window, initWithFrame: screen_bounds_cg];
 
             // Create our custom UIViewController subclass that supports
             // dynamic `preferredStatusBarStyle` overrides.
             let vc_class = register_view_controller_class();
-            let view_controller: *mut Object = msg_send![vc_class, alloc];
-            let view_controller: *mut Object = msg_send![view_controller, init];
+            let view_controller: *mut AnyObject = msg_send![vc_class, alloc];
+            let view_controller: *mut AnyObject = msg_send![view_controller, init];
 
             // Create our custom Metal view using the registered class
             let metal_view_class = register_metal_view_class();
-            let view: *mut Object = msg_send![metal_view_class, alloc];
-            let view: *mut Object = msg_send![view, initWithFrame: screen_bounds_cg];
+            let view: *mut AnyObject = msg_send![metal_view_class, alloc];
+            let view: *mut AnyObject = msg_send![view, initWithFrame: screen_bounds_cg];
 
             // Configure the Metal layer — wgpu will use it for rendering but
             // we still need to set contentsScale so the drawable size is correct.
-            let layer: *mut Object = msg_send![view, layer];
+            let layer: *mut AnyObject = msg_send![view, layer];
             let scale: core_graphics::base::CGFloat = msg_send![screen_obj, scale];
             let _: () = msg_send![layer, setContentsScale: scale];
 
@@ -553,7 +549,7 @@ impl IosWindow {
             // Uses our custom GPUITextInputView which implements UIKeyInput
             // so iOS actually routes keyboard text to us.
             let text_input_class = register_text_input_view_class();
-            let text_input_view: *mut Object = msg_send![text_input_class, alloc];
+            let text_input_view: *mut AnyObject = msg_send![text_input_class, alloc];
             let text_input_frame = core_graphics::geometry::CGRect {
                 origin: core_graphics::geometry::CGPoint { x: 0.0, y: 0.0 },
                 size: core_graphics::geometry::CGSize {
@@ -561,7 +557,7 @@ impl IosWindow {
                     height: 1.0,
                 },
             };
-            let text_input_view: *mut Object =
+            let text_input_view: *mut AnyObject =
                 msg_send![text_input_view, initWithFrame: text_input_frame];
             let _: () = msg_send![text_input_view, setAlpha: 0.01_f64];
             let _: () = msg_send![text_input_view, setUserInteractionEnabled: YES];
@@ -668,12 +664,12 @@ impl IosWindow {
     }
 
     /// Get the raw pointer to the UIViewController.
-    pub fn view_controller_ptr(&self) -> *mut Object {
+    pub fn view_controller_ptr(&self) -> *mut AnyObject {
         self.view_controller
     }
 
     /// Get the raw pointer to the GPUIMetalView.
-    pub fn metal_view_ptr(&self) -> *mut Object {
+    pub fn metal_view_ptr(&self) -> *mut AnyObject {
         self.view
     }
 
@@ -705,16 +701,16 @@ impl IosWindow {
     /// keyboard height and allow the UI to shift content above the keyboard.
     pub(crate) fn register_keyboard_observers(&self) {
         unsafe {
-            let notification_center: *mut Object =
+            let notification_center: *mut AnyObject =
                 msg_send![class!(NSNotificationCenter), defaultCenter];
 
             // Helper to create an NSString from a Rust &str.
-            fn make_nsstring(s: &str) -> *mut Object {
+            fn make_nsstring(s: &str) -> *mut AnyObject {
                 let cls = class!(NSString);
                 let bytes = s.as_ptr() as *const c_void;
                 let len = s.len();
                 unsafe {
-                    let ns: *mut Object = msg_send![cls, alloc];
+                    let ns: *mut AnyObject = msg_send![cls, alloc];
                     msg_send![ns, initWithBytes:bytes length:len encoding:4u64] // NSUTF8StringEncoding
                 }
             }
@@ -724,16 +720,16 @@ impl IosWindow {
 
             // Block that fires when the keyboard appears — extracts the
             // end-frame height and stores it in the global atomic.
-            let show_block = block::ConcreteBlock::new(move |notification: *mut Object| {
+            let show_block = block::ConcreteBlock::new(move |notification: *mut AnyObject| {
                 if notification.is_null() {
                     return;
                 }
-                let user_info: *mut Object = msg_send![notification, userInfo];
+                let user_info: *mut AnyObject = msg_send![notification, userInfo];
                 if user_info.is_null() {
                     return;
                 }
                 let frame_key = make_nsstring("UIKeyboardFrameEndUserInfoKey");
-                let frame_value: *mut Object = msg_send![user_info, objectForKey: frame_key];
+                let frame_value: *mut AnyObject = msg_send![user_info, objectForKey: frame_key];
                 if frame_value.is_null() {
                     return;
                 }
@@ -744,22 +740,22 @@ impl IosWindow {
             });
             let show_block = show_block.copy();
 
-            let hide_block = block::ConcreteBlock::new(move |_notification: *mut Object| {
+            let hide_block = block::ConcreteBlock::new(move |_notification: *mut AnyObject| {
                 log::info!("GPUI iOS: Keyboard will hide");
                 crate::set_keyboard_height(0.0);
             });
             let hide_block = hide_block.copy();
 
-            let _: *mut Object = msg_send![notification_center,
+            let _: *mut AnyObject = msg_send![notification_center,
                 addObserverForName: show_name
-                object: std::ptr::null::<Object>()
-                queue: std::ptr::null::<Object>()
+                object: std::ptr::null::<AnyObject>()
+                queue: std::ptr::null::<AnyObject>()
                 usingBlock: &*show_block
             ];
-            let _: *mut Object = msg_send![notification_center,
+            let _: *mut AnyObject = msg_send![notification_center,
                 addObserverForName: hide_name
-                object: std::ptr::null::<Object>()
-                queue: std::ptr::null::<Object>()
+                object: std::ptr::null::<AnyObject>()
+                queue: std::ptr::null::<AnyObject>()
                 usingBlock: &*hide_block
             ];
 
@@ -785,7 +781,7 @@ impl IosWindow {
     /// near a button or tab doesn't accidentally trigger navigation.
     /// Interactive screens use `MouseMove` to track the finger during drags
     /// and `MouseUp` to detect the end of a throw/drag gesture.
-    pub fn handle_touch(&self, touch: *mut Object, _event: *mut Object) {
+    pub fn handle_touch(&self, touch: *mut AnyObject, _event: *mut AnyObject) {
         let position = touch_location_in_view(touch, self.view);
         let phase = touch_phase(touch);
         let tap_count = touch_tap_count(touch);
@@ -1091,7 +1087,7 @@ impl IosWindow {
             // Defer becomeFirstResponder to the next run-loop iteration.
             let _: () = msg_send![self.text_input_view,
                 performSelector: sel!(becomeFirstResponder)
-                withObject: ptr::null::<Object>()
+                withObject: ptr::null::<AnyObject>()
                 afterDelay: 0.0_f64
             ];
             log::info!("GPUI iOS: show_keyboard_with_type done");
@@ -1107,14 +1103,14 @@ impl IosWindow {
         unsafe {
             let _: () = msg_send![self.text_input_view,
                 performSelector: sel!(resignFirstResponder)
-                withObject: ptr::null::<Object>()
+                withObject: ptr::null::<AnyObject>()
                 afterDelay: 0.0_f64
             ];
         }
     }
 
     /// Handle text input from the software keyboard
-    pub fn handle_text_input(&self, text: *mut Object) {
+    pub fn handle_text_input(&self, text: *mut AnyObject) {
         if text.is_null() {
             return;
         }
@@ -1266,7 +1262,7 @@ impl IosWindow {
     pub fn handle_layout_change(&self) {
         unsafe {
             let view_bounds: core_graphics::geometry::CGRect = msg_send![self.view, bounds];
-            let screen: *mut Object = msg_send![class!(UIScreen), mainScreen];
+            let screen: *mut AnyObject = msg_send![class!(UIScreen), mainScreen];
             let scale: core_graphics::base::CGFloat = msg_send![screen, scale];
 
             let new_w = view_bounds.size.width as f32;
@@ -1301,7 +1297,7 @@ impl IosWindow {
 
             // Update the Metal layer's contentsScale so the drawable has the
             // correct pixel dimensions.
-            let layer: *mut Object = msg_send![self.view, layer];
+            let layer: *mut AnyObject = msg_send![self.view, layer];
             let _: () = msg_send![layer, setContentsScale: scale];
 
             // Update the wgpu renderer's surface configuration.
@@ -1378,7 +1374,7 @@ impl PlatformWindow for IosWindow {
 
     fn appearance(&self) -> WindowAppearance {
         unsafe {
-            let trait_collection: *mut Object = msg_send![self.view, traitCollection];
+            let trait_collection: *mut AnyObject = msg_send![self.view, traitCollection];
             let style: i64 = msg_send![trait_collection, userInterfaceStyle];
             match style {
                 2 => WindowAppearance::Dark,
@@ -1429,12 +1425,12 @@ impl PlatformWindow for IosWindow {
 
             let alert_style: i64 = 1; // UIAlertControllerStyleAlert
 
-            let title_str: *mut Object =
+            let title_str: *mut AnyObject =
                 msg_send![class!(NSString), stringWithUTF8String: title.as_ptr()];
-            let message_str: *mut Object =
+            let message_str: *mut AnyObject =
                 msg_send![class!(NSString), stringWithUTF8String: message.as_ptr()];
 
-            let alert: *mut Object = msg_send![
+            let alert: *mut AnyObject = msg_send![
                 class!(UIAlertController),
                 alertControllerWithTitle: title_str
                 message: message_str
@@ -1443,7 +1439,7 @@ impl PlatformWindow for IosWindow {
 
             // Add buttons
             for button in answers.iter() {
-                let button_title: *mut Object = msg_send![
+                let button_title: *mut AnyObject = msg_send![
                     class!(NSString),
                     stringWithUTF8String: button.label().as_str().as_ptr()
                 ];
@@ -1451,11 +1447,11 @@ impl PlatformWindow for IosWindow {
                 let action_style: i64 = if button.is_cancel() { 1 } else { 0 }; // UIAlertActionStyleCancel or Default
 
                 // Note: In production, this would need a block that calls tx.send(index)
-                let action: *mut Object = msg_send![
+                let action: *mut AnyObject = msg_send![
                     class!(UIAlertAction),
                     actionWithTitle: button_title
                     style: action_style
-                    handler: ptr::null::<Object>()
+                    handler: ptr::null::<AnyObject>()
                 ];
 
                 let _: () = msg_send![alert, addAction: action];
@@ -1466,7 +1462,7 @@ impl PlatformWindow for IosWindow {
                 self.view_controller,
                 presentViewController: alert
                 animated: YES
-                completion: ptr::null::<Object>()
+                completion: ptr::null::<AnyObject>()
             ];
         }
 
@@ -1481,8 +1477,8 @@ impl PlatformWindow for IosWindow {
 
     fn is_active(&self) -> bool {
         unsafe {
-            let app: *mut Object = msg_send![class!(UIApplication), sharedApplication];
-            let key_window: *mut Object = msg_send![app, keyWindow];
+            let app: *mut AnyObject = msg_send![class!(UIApplication), sharedApplication];
+            let key_window: *mut AnyObject = msg_send![app, keyWindow];
             self.window == key_window
         }
     }

--- a/src/ios/window.rs
+++ b/src/ios/window.rs
@@ -723,6 +723,9 @@ impl IosWindow {
                 let frame_key = unsafe { make_nsstring("UIKeyboardFrameEndUserInfoKey") };
                 let frame_value: *mut AnyObject =
                     unsafe { msg_send![user_info, objectForKey: frame_key] };
+                unsafe {
+                    let _: () = msg_send![frame_key, release];
+                }
                 if frame_value.is_null() {
                     return;
                 }
@@ -743,12 +746,14 @@ impl IosWindow {
                 queue: std::ptr::null::<AnyObject>()
                 usingBlock: &*show_block
             ];
+            let _: () = msg_send![show_name, release];
             let _: *mut AnyObject = msg_send![notification_center,
                 addObserverForName: hide_name
                 object: std::ptr::null::<AnyObject>()
                 queue: std::ptr::null::<AnyObject>()
                 usingBlock: &*hide_block
             ];
+            let _: () = msg_send![hide_name, release];
 
             // Leak the blocks so they live for the app lifetime.
             std::mem::forget(show_block);

--- a/src/ios/window.rs
+++ b/src/ios/window.rs
@@ -242,7 +242,8 @@ fn register_metal_view_class() -> &'static AnyClass {
             );
             decl.add_method(
                 sel!(touchesCancelled:withEvent:),
-                touches_cancelled as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject, *mut AnyObject),
+                touches_cancelled
+                    as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject, *mut AnyObject),
             );
         }
 
@@ -331,7 +332,11 @@ fn register_text_input_view_class() -> &'static AnyClass {
         unsafe extern "C" fn get_autocapitalization_type(this: *mut AnyObject, _sel: Sel) -> isize {
             *(*this).get_ivar::<isize>("_autocapitalizationType")
         }
-        unsafe extern "C" fn set_autocapitalization_type(this: *mut AnyObject, _sel: Sel, val: isize) {
+        unsafe extern "C" fn set_autocapitalization_type(
+            this: *mut AnyObject,
+            _sel: Sel,
+            val: isize,
+        ) {
             *(*this).get_mut_ivar::<isize>("_autocapitalizationType") = val;
         }
 
@@ -972,7 +977,12 @@ impl IosWindow {
             unsafe impl Encode for UIEdgeInsets {
                 const ENCODING: Encoding = Encoding::Struct(
                     "UIEdgeInsets",
-                    &[Encoding::Double, Encoding::Double, Encoding::Double, Encoding::Double],
+                    &[
+                        Encoding::Double,
+                        Encoding::Double,
+                        Encoding::Double,
+                        Encoding::Double,
+                    ],
                 );
             }
 

--- a/src/packages/audio/ios.rs
+++ b/src/packages/audio/ios.rs
@@ -1,4 +1,5 @@
 use super::{LoopMode, PlayerState};
+use objc2::encode::{Encode, Encoding, RefEncode};
 use objc2::runtime::AnyObject;
 use objc2::{class, msg_send, sel};
 use std::collections::HashMap;
@@ -316,6 +317,22 @@ struct CMTime {
     timescale: i32,
     flags: u32,
     epoch: i64,
+}
+
+unsafe impl Encode for CMTime {
+    const ENCODING: Encoding = Encoding::Struct(
+        "CMTime",
+        &[
+            Encoding::LongLong,
+            Encoding::Int,
+            Encoding::UInt,
+            Encoding::LongLong,
+        ],
+    );
+}
+
+unsafe impl RefEncode for CMTime {
+    const ENCODING_REF: Encoding = Encoding::Pointer(&Self::ENCODING);
 }
 
 /// CMTimeMake(value, timescale) — construct a CMTime.

--- a/src/packages/audio/ios.rs
+++ b/src/packages/audio/ios.rs
@@ -76,6 +76,9 @@ pub fn set_url(id: u32, url: &str) -> Result<Option<u64>, String> {
                 if p.is_null() {
                     return Err("Failed to create AVPlayer".into());
                 }
+                // playerWithPlayerItem: returns an autoreleased object; retain it
+                // since it will be stored across run-loop iterations.
+                let _: () = msg_send![p, retain];
                 entry.player = p;
                 entry.started = false;
                 Ok(p)
@@ -114,6 +117,9 @@ pub fn set_file_path(id: u32, path: &str) -> Result<Option<u64>, String> {
                 if p.is_null() {
                     return Err("Failed to create AVPlayer".into());
                 }
+                // playerWithPlayerItem: returns an autoreleased object; retain it
+                // since it will be stored across run-loop iterations.
+                let _: () = msg_send![p, retain];
                 entry.player = p;
                 entry.started = false;
                 Ok(p)

--- a/src/packages/audio/ios.rs
+++ b/src/packages/audio/ios.rs
@@ -1,6 +1,6 @@
 use super::{LoopMode, PlayerState};
-use objc::runtime::Object;
-use objc::{class, msg_send, sel, sel_impl};
+use objc2::runtime::AnyObject;
+use objc2::{class, msg_send, sel};
 use std::collections::HashMap;
 use std::ffi::c_void;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -8,7 +8,7 @@ use std::sync::Mutex;
 
 /// Tracks whether each player was explicitly started (to distinguish Paused from Ready).
 struct PlayerEntry {
-    player: *mut Object,
+    player: *mut AnyObject,
     started: bool,
 }
 
@@ -57,7 +57,7 @@ pub fn set_url(id: u32, url: &str) -> Result<Option<u64>, String> {
         let ns_url = nsurl_from_str(url)?;
 
         // Create AVPlayerItem with URL
-        let player_item: *mut Object = msg_send![class!(AVPlayerItem), playerItemWithURL: ns_url];
+        let player_item: *mut AnyObject = msg_send![class!(AVPlayerItem), playerItemWithURL: ns_url];
         if player_item.is_null() {
             return Err("Failed to create AVPlayerItem".into());
         }
@@ -69,7 +69,7 @@ pub fn set_url(id: u32, url: &str) -> Result<Option<u64>, String> {
                 let _: () = msg_send![entry.player, replaceCurrentItemWithPlayerItem: player_item];
                 Ok(entry.player)
             } else {
-                let p: *mut Object = msg_send![class!(AVPlayer), playerWithPlayerItem: player_item];
+                let p: *mut AnyObject = msg_send![class!(AVPlayer), playerWithPlayerItem: player_item];
                 if p.is_null() {
                     return Err("Failed to create AVPlayer".into());
                 }
@@ -90,12 +90,12 @@ pub fn set_file_path(id: u32, path: &str) -> Result<Option<u64>, String> {
     unsafe {
         // Build file:// URL from path
         let ns_string = nsstring_from_str(path);
-        let ns_url: *mut Object = msg_send![class!(NSURL), fileURLWithPath: ns_string];
+        let ns_url: *mut AnyObject = msg_send![class!(NSURL), fileURLWithPath: ns_string];
         if ns_url.is_null() {
             return Err("Failed to create file URL".into());
         }
 
-        let player_item: *mut Object = msg_send![class!(AVPlayerItem), playerItemWithURL: ns_url];
+        let player_item: *mut AnyObject = msg_send![class!(AVPlayerItem), playerItemWithURL: ns_url];
         if player_item.is_null() {
             return Err("Failed to create AVPlayerItem".into());
         }
@@ -105,7 +105,7 @@ pub fn set_file_path(id: u32, path: &str) -> Result<Option<u64>, String> {
                 let _: () = msg_send![entry.player, replaceCurrentItemWithPlayerItem: player_item];
                 Ok(entry.player)
             } else {
-                let p: *mut Object = msg_send![class!(AVPlayer), playerWithPlayerItem: player_item];
+                let p: *mut AnyObject = msg_send![class!(AVPlayer), playerWithPlayerItem: player_item];
                 if p.is_null() {
                     return Err("Failed to create AVPlayer".into());
                 }
@@ -342,25 +342,25 @@ fn cmtime_to_ms(time: CMTime) -> i64 {
 
 // ── ObjC string/URL helpers ─────────────────────────────────────────────────
 
-unsafe fn nsstring_from_str(s: &str) -> *mut Object {
+unsafe fn nsstring_from_str(s: &str) -> *mut AnyObject {
     let cls = class!(NSString);
     let bytes = s.as_ptr() as *const c_void;
     let len = s.len();
     // initWithBytes:length:encoding: — NSUTF8StringEncoding = 4
-    let ns_string: *mut Object = msg_send![cls, alloc];
-    let ns_string: *mut Object = msg_send![ns_string, initWithBytes:bytes length:len encoding:4u64];
+    let ns_string: *mut AnyObject = msg_send![cls, alloc];
+    let ns_string: *mut AnyObject = msg_send![ns_string, initWithBytes:bytes length:len encoding:4u64];
     ns_string
 }
 
-unsafe fn nsurl_from_str(url: &str) -> Result<*mut Object, String> {
+unsafe fn nsurl_from_str(url: &str) -> Result<*mut AnyObject, String> {
     let ns_string = nsstring_from_str(url);
     if ns_string.is_null() {
         return Err("Failed to create NSString".into());
     }
-    let ns_url: *mut Object = msg_send![class!(NSURL), URLWithString: ns_string];
+    let ns_url: *mut AnyObject = msg_send![class!(NSURL), URLWithString: ns_string];
     if ns_url.is_null() {
         // Maybe it's a file path
-        let ns_url: *mut Object = msg_send![class!(NSURL), fileURLWithPath: ns_string];
+        let ns_url: *mut AnyObject = msg_send![class!(NSURL), fileURLWithPath: ns_string];
         if ns_url.is_null() {
             return Err("Failed to create NSURL".into());
         }
@@ -370,8 +370,8 @@ unsafe fn nsurl_from_str(url: &str) -> Result<*mut Object, String> {
 }
 
 /// Get the duration in ms from an AVPlayer's currentItem.
-unsafe fn get_duration_from_player(player: *mut Object) -> u64 {
-    let item: *mut Object = msg_send![player, currentItem];
+unsafe fn get_duration_from_player(player: *mut AnyObject) -> u64 {
+    let item: *mut AnyObject = msg_send![player, currentItem];
     if item.is_null() {
         return 0;
     }

--- a/src/packages/audio/ios.rs
+++ b/src/packages/audio/ios.rs
@@ -58,7 +58,8 @@ pub fn set_url(id: u32, url: &str) -> Result<Option<u64>, String> {
         let ns_url = nsurl_from_str(url)?;
 
         // Create AVPlayerItem with URL
-        let player_item: *mut AnyObject = msg_send![class!(AVPlayerItem), playerItemWithURL: ns_url];
+        let player_item: *mut AnyObject =
+            msg_send![class!(AVPlayerItem), playerItemWithURL: ns_url];
         if player_item.is_null() {
             return Err("Failed to create AVPlayerItem".into());
         }
@@ -70,7 +71,8 @@ pub fn set_url(id: u32, url: &str) -> Result<Option<u64>, String> {
                 let _: () = msg_send![entry.player, replaceCurrentItemWithPlayerItem: player_item];
                 Ok(entry.player)
             } else {
-                let p: *mut AnyObject = msg_send![class!(AVPlayer), playerWithPlayerItem: player_item];
+                let p: *mut AnyObject =
+                    msg_send![class!(AVPlayer), playerWithPlayerItem: player_item];
                 if p.is_null() {
                     return Err("Failed to create AVPlayer".into());
                 }
@@ -96,7 +98,8 @@ pub fn set_file_path(id: u32, path: &str) -> Result<Option<u64>, String> {
             return Err("Failed to create file URL".into());
         }
 
-        let player_item: *mut AnyObject = msg_send![class!(AVPlayerItem), playerItemWithURL: ns_url];
+        let player_item: *mut AnyObject =
+            msg_send![class!(AVPlayerItem), playerItemWithURL: ns_url];
         if player_item.is_null() {
             return Err("Failed to create AVPlayerItem".into());
         }
@@ -106,7 +109,8 @@ pub fn set_file_path(id: u32, path: &str) -> Result<Option<u64>, String> {
                 let _: () = msg_send![entry.player, replaceCurrentItemWithPlayerItem: player_item];
                 Ok(entry.player)
             } else {
-                let p: *mut AnyObject = msg_send![class!(AVPlayer), playerWithPlayerItem: player_item];
+                let p: *mut AnyObject =
+                    msg_send![class!(AVPlayer), playerWithPlayerItem: player_item];
                 if p.is_null() {
                     return Err("Failed to create AVPlayer".into());
                 }
@@ -365,7 +369,8 @@ unsafe fn nsstring_from_str(s: &str) -> *mut AnyObject {
     let len = s.len();
     // initWithBytes:length:encoding: — NSUTF8StringEncoding = 4
     let ns_string: *mut AnyObject = msg_send![cls, alloc];
-    let ns_string: *mut AnyObject = msg_send![ns_string, initWithBytes:bytes length:len encoding:4u64];
+    let ns_string: *mut AnyObject =
+        msg_send![ns_string, initWithBytes:bytes length:len encoding:4u64];
     ns_string
 }
 

--- a/src/packages/audio/ios.rs
+++ b/src/packages/audio/ios.rs
@@ -369,15 +369,10 @@ fn cmtime_to_ms(time: CMTime) -> i64 {
 
 // ── ObjC string/URL helpers ─────────────────────────────────────────────────
 
+use crate::ios::util::nsstring;
+
 unsafe fn nsstring_from_str(s: &str) -> *mut AnyObject {
-    let cls = class!(NSString);
-    let bytes = s.as_ptr() as *const c_void;
-    let len = s.len();
-    // initWithBytes:length:encoding: — NSUTF8StringEncoding = 4
-    let ns_string: *mut AnyObject = msg_send![cls, alloc];
-    let ns_string: *mut AnyObject =
-        msg_send![ns_string, initWithBytes:bytes length:len encoding:4u64];
-    ns_string
+    nsstring(s)
 }
 
 unsafe fn nsurl_from_str(url: &str) -> Result<*mut AnyObject, String> {

--- a/src/packages/battery/ios.rs
+++ b/src/packages/battery/ios.rs
@@ -1,10 +1,10 @@
 use super::BatteryState;
-use objc::runtime::Object;
-use objc::{class, msg_send, sel, sel_impl};
+use objc2::runtime::AnyObject;
+use objc2::{class, msg_send, sel};
 
 pub fn battery_level() -> i32 {
     unsafe {
-        let device: *mut Object = msg_send![class!(UIDevice), currentDevice];
+        let device: *mut AnyObject = msg_send![class!(UIDevice), currentDevice];
         let _: () = msg_send![device, setBatteryMonitoringEnabled: true];
         let level: f32 = msg_send![device, batteryLevel];
         if level < 0.0 {
@@ -17,7 +17,7 @@ pub fn battery_level() -> i32 {
 
 pub fn battery_state() -> BatteryState {
     unsafe {
-        let device: *mut Object = msg_send![class!(UIDevice), currentDevice];
+        let device: *mut AnyObject = msg_send![class!(UIDevice), currentDevice];
         let _: () = msg_send![device, setBatteryMonitoringEnabled: true];
         let state: i64 = msg_send![device, batteryState];
         // UIDeviceBatteryState: 0=unknown, 1=unplugged, 2=charging, 3=full
@@ -32,7 +32,7 @@ pub fn battery_state() -> BatteryState {
 
 pub fn is_battery_save_mode() -> bool {
     unsafe {
-        let process_info: *mut Object = msg_send![class!(NSProcessInfo), processInfo];
+        let process_info: *mut AnyObject = msg_send![class!(NSProcessInfo), processInfo];
         let low_power: bool = msg_send![process_info, isLowPowerModeEnabled];
         low_power
     }

--- a/src/packages/calendar/ios.rs
+++ b/src/packages/calendar/ios.rs
@@ -65,6 +65,7 @@ pub fn get_calendars() -> Result<Vec<Calendar>, String> {
         let calendars: *mut AnyObject =
             msg_send![store, calendarsForEntityType: EK_ENTITY_TYPE_EVENT];
         if calendars.is_null() {
+            let _: () = msg_send![store, release];
             return Ok(vec![]);
         }
 
@@ -93,6 +94,7 @@ pub fn get_calendars() -> Result<Vec<Calendar>, String> {
             });
         }
 
+        let _: () = msg_send![store, release];
         Ok(result)
     }
 }
@@ -115,6 +117,7 @@ pub fn get_events(
         let all_calendars: *mut AnyObject =
             msg_send![store, calendarsForEntityType: EK_ENTITY_TYPE_EVENT];
         if all_calendars.is_null() {
+            let _: () = msg_send![store, release];
             return Ok(vec![]);
         }
 
@@ -135,6 +138,7 @@ pub fn get_events(
         }
 
         if target_calendar.is_null() {
+            let _: () = msg_send![store, release];
             return Err(format!("Calendar not found: {}", calendar_id));
         }
 
@@ -148,11 +152,13 @@ pub fn get_events(
             calendars: calendar_array
         ];
         if predicate.is_null() {
+            let _: () = msg_send![store, release];
             return Ok(vec![]);
         }
 
         let events: *mut AnyObject = msg_send![store, eventsMatchingPredicate: predicate];
         if events.is_null() {
+            let _: () = msg_send![store, release];
             return Ok(vec![]);
         }
 
@@ -187,6 +193,7 @@ pub fn get_events(
             });
         }
 
+        let _: () = msg_send![store, release];
         Ok(result)
     }
 }
@@ -200,6 +207,7 @@ pub fn create_event(event: &CalendarEvent) -> Result<String, String> {
 
         let ek_event: *mut AnyObject = msg_send![class!(EKEvent), eventWithEventStore: store];
         if ek_event.is_null() {
+            let _: () = msg_send![store, release];
             return Err("Failed to create EKEvent".into());
         }
 
@@ -254,13 +262,16 @@ pub fn create_event(event: &CalendarEvent) -> Result<String, String> {
             if !error.is_null() {
                 let desc: *mut AnyObject = msg_send![error, localizedDescription];
                 let err_str = nsstring_to_string(desc);
+                let _: () = msg_send![store, release];
                 return Err(format!("Failed to save event: {}", err_str));
             }
+            let _: () = msg_send![store, release];
             return Err("Failed to save event".into());
         }
 
         let event_identifier: *mut AnyObject = msg_send![ek_event, eventIdentifier];
         let id_str = nsstring_to_string(event_identifier);
+        let _: () = msg_send![store, release];
         if id_str.is_empty() {
             Err("Event saved but no identifier returned".into())
         } else {
@@ -279,6 +290,7 @@ pub fn delete_event(event_id: &str) -> Result<bool, String> {
         let ns_event_id = nsstring_from_str(event_id);
         let event: *mut AnyObject = msg_send![store, eventWithIdentifier: ns_event_id];
         if event.is_null() {
+            let _: () = msg_send![store, release];
             return Ok(false);
         }
 
@@ -293,11 +305,14 @@ pub fn delete_event(event_id: &str) -> Result<bool, String> {
             if !error.is_null() {
                 let desc: *mut AnyObject = msg_send![error, localizedDescription];
                 let err_str = nsstring_to_string(desc);
+                let _: () = msg_send![store, release];
                 return Err(format!("Failed to delete event: {}", err_str));
             }
+            let _: () = msg_send![store, release];
             return Err("Failed to delete event".into());
         }
 
+        let _: () = msg_send![store, release];
         Ok(true)
     }
 }

--- a/src/packages/calendar/ios.rs
+++ b/src/packages/calendar/ios.rs
@@ -62,7 +62,8 @@ pub fn get_calendars() -> Result<Vec<Calendar>, String> {
             return Err("Failed to create EKEventStore".into());
         }
 
-        let calendars: *mut AnyObject = msg_send![store, calendarsForEntityType: EK_ENTITY_TYPE_EVENT];
+        let calendars: *mut AnyObject =
+            msg_send![store, calendarsForEntityType: EK_ENTITY_TYPE_EVENT];
         if calendars.is_null() {
             return Ok(vec![]);
         }

--- a/src/packages/calendar/ios.rs
+++ b/src/packages/calendar/ios.rs
@@ -1,6 +1,6 @@
 use super::{Calendar, CalendarEvent};
-use objc::runtime::Object;
-use objc::{class, msg_send, sel, sel_impl};
+use objc2::runtime::AnyObject;
+use objc2::{class, msg_send, sel};
 
 /// EKEntityType.event = 0
 const EK_ENTITY_TYPE_EVENT: u64 = 0;
@@ -9,21 +9,21 @@ const EK_ENTITY_TYPE_EVENT: u64 = 0;
 const EK_SPAN_THIS_EVENT: u64 = 0;
 
 /// Create an EKEventStore instance.
-unsafe fn new_event_store() -> *mut Object {
-    let store: *mut Object = msg_send![class!(EKEventStore), alloc];
-    let store: *mut Object = msg_send![store, init];
+unsafe fn new_event_store() -> *mut AnyObject {
+    let store: *mut AnyObject = msg_send![class!(EKEventStore), alloc];
+    let store: *mut AnyObject = msg_send![store, init];
     store
 }
 
 /// Convert a Unix timestamp in milliseconds to an NSDate.
-unsafe fn nsdate_from_ms(ms: i64) -> *mut Object {
+unsafe fn nsdate_from_ms(ms: i64) -> *mut AnyObject {
     let seconds = (ms as f64) / 1000.0;
-    let date: *mut Object = msg_send![class!(NSDate), dateWithTimeIntervalSince1970: seconds];
+    let date: *mut AnyObject = msg_send![class!(NSDate), dateWithTimeIntervalSince1970: seconds];
     date
 }
 
 /// Convert an NSDate to a Unix timestamp in milliseconds.
-unsafe fn ms_from_nsdate(date: *mut Object) -> i64 {
+unsafe fn ms_from_nsdate(date: *mut AnyObject) -> i64 {
     if date.is_null() {
         return 0;
     }
@@ -32,7 +32,7 @@ unsafe fn ms_from_nsdate(date: *mut Object) -> i64 {
 }
 
 /// Read a UTF-8 string from an NSString pointer. Returns empty string if null.
-unsafe fn nsstring_to_string(ns: *mut Object) -> String {
+unsafe fn nsstring_to_string(ns: *mut AnyObject) -> String {
     if ns.is_null() {
         return String::new();
     }
@@ -45,9 +45,9 @@ unsafe fn nsstring_to_string(ns: *mut Object) -> String {
 }
 
 /// Create an NSString from a Rust &str.
-unsafe fn nsstring_from_str(s: &str) -> *mut Object {
-    let ns: *mut Object = msg_send![class!(NSString), alloc];
-    let ns: *mut Object = msg_send![ns,
+unsafe fn nsstring_from_str(s: &str) -> *mut AnyObject {
+    let ns: *mut AnyObject = msg_send![class!(NSString), alloc];
+    let ns: *mut AnyObject = msg_send![ns,
         initWithBytes: s.as_ptr() as *const std::ffi::c_void
         length: s.len()
         encoding: 4u64  // NSUTF8StringEncoding
@@ -62,7 +62,7 @@ pub fn get_calendars() -> Result<Vec<Calendar>, String> {
             return Err("Failed to create EKEventStore".into());
         }
 
-        let calendars: *mut Object = msg_send![store, calendarsForEntityType: EK_ENTITY_TYPE_EVENT];
+        let calendars: *mut AnyObject = msg_send![store, calendarsForEntityType: EK_ENTITY_TYPE_EVENT];
         if calendars.is_null() {
             return Ok(vec![]);
         }
@@ -71,17 +71,17 @@ pub fn get_calendars() -> Result<Vec<Calendar>, String> {
         let mut result = Vec::with_capacity(count as usize);
 
         for i in 0..count {
-            let cal: *mut Object = msg_send![calendars, objectAtIndex: i];
+            let cal: *mut AnyObject = msg_send![calendars, objectAtIndex: i];
             if cal.is_null() {
                 continue;
             }
 
-            let identifier: *mut Object = msg_send![cal, calendarIdentifier];
-            let title: *mut Object = msg_send![cal, title];
+            let identifier: *mut AnyObject = msg_send![cal, calendarIdentifier];
+            let title: *mut AnyObject = msg_send![cal, title];
             let allows_modifications: bool = msg_send![cal, allowsContentModifications];
 
             // Get calendar color from CGColor
-            let cg_color: *mut Object = msg_send![cal, CGColor];
+            let cg_color: *mut AnyObject = msg_send![cal, CGColor];
             let color = cgcolor_to_argb(cg_color);
 
             result.push(Calendar {
@@ -111,21 +111,21 @@ pub fn get_events(
         let end_date = nsdate_from_ms(end_ms);
 
         // Find the calendar with matching identifier
-        let all_calendars: *mut Object =
+        let all_calendars: *mut AnyObject =
             msg_send![store, calendarsForEntityType: EK_ENTITY_TYPE_EVENT];
         if all_calendars.is_null() {
             return Ok(vec![]);
         }
 
         let cal_count: u64 = msg_send![all_calendars, count];
-        let mut target_calendar: *mut Object = std::ptr::null_mut();
+        let mut target_calendar: *mut AnyObject = std::ptr::null_mut();
 
         for i in 0..cal_count {
-            let cal: *mut Object = msg_send![all_calendars, objectAtIndex: i];
+            let cal: *mut AnyObject = msg_send![all_calendars, objectAtIndex: i];
             if cal.is_null() {
                 continue;
             }
-            let identifier: *mut Object = msg_send![cal, calendarIdentifier];
+            let identifier: *mut AnyObject = msg_send![cal, calendarIdentifier];
             let id_str = nsstring_to_string(identifier);
             if id_str == calendar_id {
                 target_calendar = cal;
@@ -138,10 +138,10 @@ pub fn get_events(
         }
 
         // Create an NSArray with just this calendar
-        let calendar_array: *mut Object =
+        let calendar_array: *mut AnyObject =
             msg_send![class!(NSArray), arrayWithObject: target_calendar];
 
-        let predicate: *mut Object = msg_send![store,
+        let predicate: *mut AnyObject = msg_send![store,
             predicateForEventsWithStartDate: start_date
             endDate: end_date
             calendars: calendar_array
@@ -150,7 +150,7 @@ pub fn get_events(
             return Ok(vec![]);
         }
 
-        let events: *mut Object = msg_send![store, eventsMatchingPredicate: predicate];
+        let events: *mut AnyObject = msg_send![store, eventsMatchingPredicate: predicate];
         if events.is_null() {
             return Ok(vec![]);
         }
@@ -159,20 +159,20 @@ pub fn get_events(
         let mut result = Vec::with_capacity(count as usize);
 
         for i in 0..count {
-            let event: *mut Object = msg_send![events, objectAtIndex: i];
+            let event: *mut AnyObject = msg_send![events, objectAtIndex: i];
             if event.is_null() {
                 continue;
             }
 
-            let event_identifier: *mut Object = msg_send![event, eventIdentifier];
-            let title: *mut Object = msg_send![event, title];
-            let notes: *mut Object = msg_send![event, notes];
-            let location: *mut Object = msg_send![event, location];
-            let start: *mut Object = msg_send![event, startDate];
-            let end: *mut Object = msg_send![event, endDate];
+            let event_identifier: *mut AnyObject = msg_send![event, eventIdentifier];
+            let title: *mut AnyObject = msg_send![event, title];
+            let notes: *mut AnyObject = msg_send![event, notes];
+            let location: *mut AnyObject = msg_send![event, location];
+            let start: *mut AnyObject = msg_send![event, startDate];
+            let end: *mut AnyObject = msg_send![event, endDate];
             let is_all_day: bool = msg_send![event, isAllDay];
-            let cal: *mut Object = msg_send![event, calendar];
-            let cal_id: *mut Object = msg_send![cal, calendarIdentifier];
+            let cal: *mut AnyObject = msg_send![event, calendar];
+            let cal_id: *mut AnyObject = msg_send![cal, calendarIdentifier];
 
             result.push(CalendarEvent {
                 id: nsstring_to_string(event_identifier),
@@ -197,7 +197,7 @@ pub fn create_event(event: &CalendarEvent) -> Result<String, String> {
             return Err("Failed to create EKEventStore".into());
         }
 
-        let ek_event: *mut Object = msg_send![class!(EKEvent), eventWithEventStore: store];
+        let ek_event: *mut AnyObject = msg_send![class!(EKEvent), eventWithEventStore: store];
         if ek_event.is_null() {
             return Err("Failed to create EKEvent".into());
         }
@@ -224,16 +224,16 @@ pub fn create_event(event: &CalendarEvent) -> Result<String, String> {
         let _: () = msg_send![ek_event, setAllDay: event.all_day];
 
         // Find and set the calendar
-        let all_calendars: *mut Object =
+        let all_calendars: *mut AnyObject =
             msg_send![store, calendarsForEntityType: EK_ENTITY_TYPE_EVENT];
         if !all_calendars.is_null() {
             let cal_count: u64 = msg_send![all_calendars, count];
             for i in 0..cal_count {
-                let cal: *mut Object = msg_send![all_calendars, objectAtIndex: i];
+                let cal: *mut AnyObject = msg_send![all_calendars, objectAtIndex: i];
                 if cal.is_null() {
                     continue;
                 }
-                let identifier: *mut Object = msg_send![cal, calendarIdentifier];
+                let identifier: *mut AnyObject = msg_send![cal, calendarIdentifier];
                 let id_str = nsstring_to_string(identifier);
                 if id_str == event.calendar_id {
                     let _: () = msg_send![ek_event, setCalendar: cal];
@@ -242,7 +242,7 @@ pub fn create_event(event: &CalendarEvent) -> Result<String, String> {
             }
         }
 
-        let mut error: *mut Object = std::ptr::null_mut();
+        let mut error: *mut AnyObject = std::ptr::null_mut();
         let success: bool = msg_send![store,
             saveEvent: ek_event
             span: EK_SPAN_THIS_EVENT
@@ -251,14 +251,14 @@ pub fn create_event(event: &CalendarEvent) -> Result<String, String> {
 
         if !success {
             if !error.is_null() {
-                let desc: *mut Object = msg_send![error, localizedDescription];
+                let desc: *mut AnyObject = msg_send![error, localizedDescription];
                 let err_str = nsstring_to_string(desc);
                 return Err(format!("Failed to save event: {}", err_str));
             }
             return Err("Failed to save event".into());
         }
 
-        let event_identifier: *mut Object = msg_send![ek_event, eventIdentifier];
+        let event_identifier: *mut AnyObject = msg_send![ek_event, eventIdentifier];
         let id_str = nsstring_to_string(event_identifier);
         if id_str.is_empty() {
             Err("Event saved but no identifier returned".into())
@@ -276,12 +276,12 @@ pub fn delete_event(event_id: &str) -> Result<bool, String> {
         }
 
         let ns_event_id = nsstring_from_str(event_id);
-        let event: *mut Object = msg_send![store, eventWithIdentifier: ns_event_id];
+        let event: *mut AnyObject = msg_send![store, eventWithIdentifier: ns_event_id];
         if event.is_null() {
             return Ok(false);
         }
 
-        let mut error: *mut Object = std::ptr::null_mut();
+        let mut error: *mut AnyObject = std::ptr::null_mut();
         let success: bool = msg_send![store,
             removeEvent: event
             span: EK_SPAN_THIS_EVENT
@@ -290,7 +290,7 @@ pub fn delete_event(event_id: &str) -> Result<bool, String> {
 
         if !success {
             if !error.is_null() {
-                let desc: *mut Object = msg_send![error, localizedDescription];
+                let desc: *mut AnyObject = msg_send![error, localizedDescription];
                 let err_str = nsstring_to_string(desc);
                 return Err(format!("Failed to delete event: {}", err_str));
             }
@@ -302,7 +302,7 @@ pub fn delete_event(event_id: &str) -> Result<bool, String> {
 }
 
 /// Convert a CGColor to an ARGB u32 value.
-unsafe fn cgcolor_to_argb(cg_color: *mut Object) -> u32 {
+unsafe fn cgcolor_to_argb(cg_color: *mut AnyObject) -> u32 {
     if cg_color.is_null() {
         return 0xFF000000; // Default to opaque black
     }
@@ -310,7 +310,7 @@ unsafe fn cgcolor_to_argb(cg_color: *mut Object) -> u32 {
     // Get the number of components
     let num_components: usize = {
         extern "C" {
-            fn CGColorGetNumberOfComponents(color: *const Object) -> usize;
+            fn CGColorGetNumberOfComponents(color: *const AnyObject) -> usize;
         }
         CGColorGetNumberOfComponents(cg_color)
     };
@@ -318,7 +318,7 @@ unsafe fn cgcolor_to_argb(cg_color: *mut Object) -> u32 {
     // Get the component array
     let components: *const f64 = {
         extern "C" {
-            fn CGColorGetComponents(color: *const Object) -> *const f64;
+            fn CGColorGetComponents(color: *const AnyObject) -> *const f64;
         }
         CGColorGetComponents(cg_color)
     };

--- a/src/packages/calendar/ios.rs
+++ b/src/packages/calendar/ios.rs
@@ -44,15 +44,10 @@ unsafe fn nsstring_to_string(ns: *mut AnyObject) -> String {
     c_str.to_string_lossy().into_owned()
 }
 
-/// Create an NSString from a Rust &str.
+use crate::ios::util::nsstring;
+
 unsafe fn nsstring_from_str(s: &str) -> *mut AnyObject {
-    let ns: *mut AnyObject = msg_send![class!(NSString), alloc];
-    let ns: *mut AnyObject = msg_send![ns,
-        initWithBytes: s.as_ptr() as *const std::ffi::c_void
-        length: s.len()
-        encoding: 4u64  // NSUTF8StringEncoding
-    ];
-    ns
+    nsstring(s)
 }
 
 pub fn get_calendars() -> Result<Vec<Calendar>, String> {

--- a/src/packages/camera/ios.rs
+++ b/src/packages/camera/ios.rs
@@ -73,7 +73,14 @@ fn photo_delegate_class() -> &'static AnyClass {
             // captureOutput:didFinishProcessingPhoto:error:
             decl.add_method(
                 sel!(captureOutput:didFinishProcessingPhoto:error:),
-                photo_did_finish as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject, *mut AnyObject, *mut AnyObject),
+                photo_did_finish
+                    as extern "C" fn(
+                        *mut AnyObject,
+                        Sel,
+                        *mut AnyObject,
+                        *mut AnyObject,
+                        *mut AnyObject,
+                    ),
             );
         }
 
@@ -165,7 +172,15 @@ fn video_delegate_class() -> &'static AnyClass {
             // captureOutput:didFinishRecordingToOutputFileAtURL:fromConnections:error:
             decl.add_method(
                 sel!(captureOutput:didFinishRecordingToOutputFileAtURL:fromConnections:error:),
-                video_did_finish as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject, *mut AnyObject, *mut AnyObject, *mut AnyObject),
+                video_did_finish
+                    as extern "C" fn(
+                        *mut AnyObject,
+                        Sel,
+                        *mut AnyObject,
+                        *mut AnyObject,
+                        *mut AnyObject,
+                        *mut AnyObject,
+                    ),
             );
         }
 

--- a/src/packages/camera/ios.rs
+++ b/src/packages/camera/ios.rs
@@ -67,14 +67,13 @@ static mut PHOTO_DELEGATE_CLASS: *const AnyClass = std::ptr::null();
 fn photo_delegate_class() -> &'static AnyClass {
     REGISTER_PHOTO_DELEGATE.call_once(|| {
         let superclass = class!(NSObject);
-        let mut decl = ClassBuilder::new("GpuiPhotoCaptureDelegate", superclass).unwrap();
+        let mut decl = ClassBuilder::new(c"GpuiPhotoCaptureDelegate", superclass).unwrap();
 
         unsafe {
             // captureOutput:didFinishProcessingPhoto:error:
             decl.add_method(
                 sel!(captureOutput:didFinishProcessingPhoto:error:),
-                photo_did_finish
-                    as extern "C" fn(&AnyObject, Sel, *mut AnyObject, *mut AnyObject, *mut AnyObject),
+                photo_did_finish as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject, *mut AnyObject, *mut AnyObject),
             );
         }
 
@@ -84,7 +83,7 @@ fn photo_delegate_class() -> &'static AnyClass {
 }
 
 extern "C" fn photo_did_finish(
-    _this: &AnyObject,
+    _this: *mut AnyObject,
     _sel: Sel,
     _output: *mut AnyObject,
     photo: *mut AnyObject,
@@ -160,21 +159,13 @@ static mut VIDEO_DELEGATE_CLASS: *const AnyClass = std::ptr::null();
 fn video_delegate_class() -> &'static AnyClass {
     REGISTER_VIDEO_DELEGATE.call_once(|| {
         let superclass = class!(NSObject);
-        let mut decl = ClassBuilder::new("GpuiVideoRecordingDelegate", superclass).unwrap();
+        let mut decl = ClassBuilder::new(c"GpuiVideoRecordingDelegate", superclass).unwrap();
 
         unsafe {
             // captureOutput:didFinishRecordingToOutputFileAtURL:fromConnections:error:
             decl.add_method(
                 sel!(captureOutput:didFinishRecordingToOutputFileAtURL:fromConnections:error:),
-                video_did_finish
-                    as extern "C" fn(
-                        &AnyObject,
-                        Sel,
-                        *mut AnyObject,
-                        *mut AnyObject,
-                        *mut AnyObject,
-                        *mut AnyObject,
-                    ),
+                video_did_finish as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject, *mut AnyObject, *mut AnyObject, *mut AnyObject),
             );
         }
 
@@ -184,7 +175,7 @@ fn video_delegate_class() -> &'static AnyClass {
 }
 
 extern "C" fn video_did_finish(
-    _this: &AnyObject,
+    _this: *mut AnyObject,
     _sel: Sel,
     _output: *mut AnyObject,
     url: *mut AnyObject,

--- a/src/packages/camera/ios.rs
+++ b/src/packages/camera/ios.rs
@@ -394,7 +394,7 @@ pub fn create_camera(
         let mut error_ptr: *mut AnyObject = std::ptr::null_mut();
         let input: *mut AnyObject = msg_send![class!(AVCaptureDeviceInput),
             deviceInputWithDevice: device
-            error: &mut error_ptr as *mut *mut AnyObject
+            error: &mut error_ptr
         ];
         if input.is_null() || !error_ptr.is_null() {
             let _: () = msg_send![session, commitConfiguration];
@@ -419,7 +419,7 @@ pub fn create_camera(
                 let mut audio_err: *mut AnyObject = std::ptr::null_mut();
                 let a_input: *mut AnyObject = msg_send![class!(AVCaptureDeviceInput),
                     deviceInputWithDevice: audio_device
-                    error: &mut audio_err as *mut *mut AnyObject
+                    error: &mut audio_err
                 ];
                 if !a_input.is_null() && audio_err.is_null() {
                     let can_add_audio: BOOL = msg_send![session, canAddInput: a_input];

--- a/src/packages/camera/ios.rs
+++ b/src/packages/camera/ios.rs
@@ -2,9 +2,9 @@ use super::{
     CameraDescription, CameraHandle, CameraLensDirection, CapturedImage, ExposureMode, FlashMode,
     FocusMode, RecordedVideo, ResolutionPreset,
 };
-use objc::declare::ClassDecl;
-use objc::runtime::{Class, Object, Sel, BOOL, YES};
-use objc::{class, msg_send, sel, sel_impl};
+use objc2::ffi::{BOOL, YES};
+use objc2::runtime::{AnyClass, AnyObject, ClassBuilder, Sel};
+use objc2::{class, msg_send, sel};
 use std::collections::HashMap;
 use std::sync::{mpsc, Mutex, Once};
 
@@ -17,14 +17,14 @@ extern "C" {}
 // ── Session state ───────────────────────────────────────────────────────────
 
 struct SessionState {
-    session: *mut Object,       // AVCaptureSession
-    device: *mut Object,        // AVCaptureDevice
-    device_input: *mut Object,  // AVCaptureDeviceInput
-    photo_output: *mut Object,  // AVCapturePhotoOutput
-    video_output: *mut Object,  // AVCaptureMovieFileOutput (may be null)
-    preview_layer: *mut Object, // AVCaptureVideoPreviewLayer (may be null)
+    session: *mut AnyObject,       // AVCaptureSession
+    device: *mut AnyObject,        // AVCaptureDevice
+    device_input: *mut AnyObject,  // AVCaptureDeviceInput
+    photo_output: *mut AnyObject,  // AVCapturePhotoOutput
+    video_output: *mut AnyObject,  // AVCaptureMovieFileOutput (may be null)
+    preview_layer: *mut AnyObject, // AVCaptureVideoPreviewLayer (may be null)
     _enable_audio: bool,
-    _audio_input: *mut Object, // AVCaptureDeviceInput for audio (may be null)
+    _audio_input: *mut AnyObject, // AVCaptureDeviceInput for audio (may be null)
 }
 
 // SAFETY: all pointers are ObjC objects accessed on the main thread or under lock
@@ -50,7 +50,7 @@ fn next_id() -> usize {
 }
 
 /// Get the raw AVCaptureSession pointer for a given session ID.
-pub fn get_session_ptr(id: usize) -> Option<*mut Object> {
+pub fn get_session_ptr(id: usize) -> Option<*mut AnyObject> {
     let guard = sessions();
     guard
         .as_ref()
@@ -62,37 +62,37 @@ pub fn get_session_ptr(id: usize) -> Option<*mut Object> {
 static PHOTO_RESULT: Mutex<Option<mpsc::Sender<Result<CapturedImage, String>>>> = Mutex::new(None);
 
 static REGISTER_PHOTO_DELEGATE: Once = Once::new();
-static mut PHOTO_DELEGATE_CLASS: *const Class = std::ptr::null();
+static mut PHOTO_DELEGATE_CLASS: *const AnyClass = std::ptr::null();
 
-fn photo_delegate_class() -> &'static Class {
+fn photo_delegate_class() -> &'static AnyClass {
     REGISTER_PHOTO_DELEGATE.call_once(|| {
         let superclass = class!(NSObject);
-        let mut decl = ClassDecl::new("GpuiPhotoCaptureDelegate", superclass).unwrap();
+        let mut decl = ClassBuilder::new("GpuiPhotoCaptureDelegate", superclass).unwrap();
 
         unsafe {
             // captureOutput:didFinishProcessingPhoto:error:
             decl.add_method(
                 sel!(captureOutput:didFinishProcessingPhoto:error:),
                 photo_did_finish
-                    as extern "C" fn(&Object, Sel, *mut Object, *mut Object, *mut Object),
+                    as extern "C" fn(&AnyObject, Sel, *mut AnyObject, *mut AnyObject, *mut AnyObject),
             );
         }
 
-        unsafe { PHOTO_DELEGATE_CLASS = decl.register() };
+        unsafe { PHOTO_DELEGATE_CLASS = decl.register() as *const AnyClass };
     });
     unsafe { &*PHOTO_DELEGATE_CLASS }
 }
 
 extern "C" fn photo_did_finish(
-    _this: &Object,
+    _this: &AnyObject,
     _sel: Sel,
-    _output: *mut Object,
-    photo: *mut Object,
-    error: *mut Object,
+    _output: *mut AnyObject,
+    photo: *mut AnyObject,
+    error: *mut AnyObject,
 ) {
     let result = unsafe {
         if !error.is_null() {
-            let desc: *mut Object = msg_send![error, localizedDescription];
+            let desc: *mut AnyObject = msg_send![error, localizedDescription];
             let cstr: *const std::ffi::c_char = msg_send![desc, UTF8String];
             let msg = if !cstr.is_null() {
                 std::ffi::CStr::from_ptr(cstr)
@@ -104,7 +104,7 @@ extern "C" fn photo_did_finish(
             Err(msg)
         } else {
             // Get JPEG data
-            let jpeg_data: *mut Object = msg_send![photo, fileDataRepresentation];
+            let jpeg_data: *mut AnyObject = msg_send![photo, fileDataRepresentation];
             if jpeg_data.is_null() {
                 Err("Failed to get photo data".to_string())
             } else {
@@ -117,7 +117,7 @@ extern "C" fn photo_did_finish(
 
                 if wrote == YES {
                     // Get dimensions from CGImage
-                    let cg_image: *mut Object = msg_send![photo, CGImageRepresentation];
+                    let cg_image: *mut AnyObject = msg_send![photo, CGImageRepresentation];
                     let (width, height) = if !cg_image.is_null() {
                         let _: usize = msg_send![class!(UIImage), imageWithCGImage: cg_image];
                         // Use CGImageGetWidth/Height
@@ -146,8 +146,8 @@ extern "C" fn photo_did_finish(
 }
 
 extern "C" {
-    fn CGImageGetWidth(image: *mut Object) -> usize;
-    fn CGImageGetHeight(image: *mut Object) -> usize;
+    fn CGImageGetWidth(image: *mut AnyObject) -> usize;
+    fn CGImageGetHeight(image: *mut AnyObject) -> usize;
 }
 
 // ── Video recording delegate ────────────────────────────────────────────────
@@ -155,12 +155,12 @@ extern "C" {
 static VIDEO_RESULT: Mutex<Option<mpsc::Sender<Result<RecordedVideo, String>>>> = Mutex::new(None);
 
 static REGISTER_VIDEO_DELEGATE: Once = Once::new();
-static mut VIDEO_DELEGATE_CLASS: *const Class = std::ptr::null();
+static mut VIDEO_DELEGATE_CLASS: *const AnyClass = std::ptr::null();
 
-fn video_delegate_class() -> &'static Class {
+fn video_delegate_class() -> &'static AnyClass {
     REGISTER_VIDEO_DELEGATE.call_once(|| {
         let superclass = class!(NSObject);
-        let mut decl = ClassDecl::new("GpuiVideoRecordingDelegate", superclass).unwrap();
+        let mut decl = ClassBuilder::new("GpuiVideoRecordingDelegate", superclass).unwrap();
 
         unsafe {
             // captureOutput:didFinishRecordingToOutputFileAtURL:fromConnections:error:
@@ -168,32 +168,32 @@ fn video_delegate_class() -> &'static Class {
                 sel!(captureOutput:didFinishRecordingToOutputFileAtURL:fromConnections:error:),
                 video_did_finish
                     as extern "C" fn(
-                        &Object,
+                        &AnyObject,
                         Sel,
-                        *mut Object,
-                        *mut Object,
-                        *mut Object,
-                        *mut Object,
+                        *mut AnyObject,
+                        *mut AnyObject,
+                        *mut AnyObject,
+                        *mut AnyObject,
                     ),
             );
         }
 
-        unsafe { VIDEO_DELEGATE_CLASS = decl.register() };
+        unsafe { VIDEO_DELEGATE_CLASS = decl.register() as *const AnyClass };
     });
     unsafe { &*VIDEO_DELEGATE_CLASS }
 }
 
 extern "C" fn video_did_finish(
-    _this: &Object,
+    _this: &AnyObject,
     _sel: Sel,
-    _output: *mut Object,
-    url: *mut Object,
-    _connections: *mut Object,
-    error: *mut Object,
+    _output: *mut AnyObject,
+    url: *mut AnyObject,
+    _connections: *mut AnyObject,
+    error: *mut AnyObject,
 ) {
     let result = unsafe {
         if !error.is_null() {
-            let desc: *mut Object = msg_send![error, localizedDescription];
+            let desc: *mut AnyObject = msg_send![error, localizedDescription];
             let cstr: *const std::ffi::c_char = msg_send![desc, UTF8String];
             let msg = if !cstr.is_null() {
                 std::ffi::CStr::from_ptr(cstr)
@@ -206,7 +206,7 @@ extern "C" fn video_did_finish(
         } else if url.is_null() {
             Err("No output URL".to_string())
         } else {
-            let path_obj: *mut Object = msg_send![url, path];
+            let path_obj: *mut AnyObject = msg_send![url, path];
             let cstr: *const std::ffi::c_char = msg_send![path_obj, UTF8String];
             if !cstr.is_null() {
                 let path = std::ffi::CStr::from_ptr(cstr)
@@ -226,8 +226,8 @@ extern "C" fn video_did_finish(
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-unsafe fn nsstring(s: &str) -> *mut Object {
-    let ns: *mut Object = msg_send![class!(NSString), alloc];
+unsafe fn nsstring(s: &str) -> *mut AnyObject {
+    let ns: *mut AnyObject = msg_send![class!(NSString), alloc];
     msg_send![ns,
         initWithBytes: s.as_ptr() as *const std::ffi::c_void
         length: s.len()
@@ -246,9 +246,9 @@ fn resolution_to_preset(resolution: ResolutionPreset) -> &'static str {
     }
 }
 
-unsafe fn find_device_by_name(name: &str) -> *mut Object {
+unsafe fn find_device_by_name(name: &str) -> *mut AnyObject {
     // Use AVCaptureDeviceDiscoverySession to find all cameras
-    let device_types: *mut Object = {
+    let device_types: *mut AnyObject = {
         let wide = nsstring("AVCaptureDeviceTypeBuiltInWideAngleCamera");
         let ultra = nsstring("AVCaptureDeviceTypeBuiltInUltraWideCamera");
         let tele = nsstring("AVCaptureDeviceTypeBuiltInTelephotoCamera");
@@ -261,7 +261,7 @@ unsafe fn find_device_by_name(name: &str) -> *mut Object {
     let media_type = nsstring("vide"); // AVMediaTypeVideo
     let position: i64 = 0; // AVCaptureDevicePositionUnspecified
 
-    let discovery: *mut Object = msg_send![class!(AVCaptureDeviceDiscoverySession),
+    let discovery: *mut AnyObject = msg_send![class!(AVCaptureDeviceDiscoverySession),
         discoverySessionWithDeviceTypes: device_types
         mediaType: media_type
         position: position
@@ -271,12 +271,12 @@ unsafe fn find_device_by_name(name: &str) -> *mut Object {
         return std::ptr::null_mut();
     }
 
-    let devices: *mut Object = msg_send![discovery, devices];
+    let devices: *mut AnyObject = msg_send![discovery, devices];
     let count: usize = msg_send![devices, count];
 
     for i in 0..count {
-        let device: *mut Object = msg_send![devices, objectAtIndex: i];
-        let unique_id: *mut Object = msg_send![device, uniqueID];
+        let device: *mut AnyObject = msg_send![devices, objectAtIndex: i];
+        let unique_id: *mut AnyObject = msg_send![device, uniqueID];
         let cstr: *const std::ffi::c_char = msg_send![unique_id, UTF8String];
         if !cstr.is_null() {
             let id = std::ffi::CStr::from_ptr(cstr).to_string_lossy();
@@ -295,7 +295,7 @@ pub fn available_cameras() -> Result<Vec<CameraDescription>, String> {
     unsafe {
         // AVCaptureDeviceType is an NSString typedef, not an ObjC class.
         // Use the string constants directly.
-        let device_types: *mut Object = {
+        let device_types: *mut AnyObject = {
             let wide = nsstring("AVCaptureDeviceTypeBuiltInWideAngleCamera");
             let ultra = nsstring("AVCaptureDeviceTypeBuiltInUltraWideCamera");
             let tele = nsstring("AVCaptureDeviceTypeBuiltInTelephotoCamera");
@@ -308,7 +308,7 @@ pub fn available_cameras() -> Result<Vec<CameraDescription>, String> {
         let media_type = nsstring("vide"); // AVMediaTypeVideo
         let position: i64 = 0; // AVCaptureDevicePositionUnspecified
 
-        let discovery: *mut Object = msg_send![class!(AVCaptureDeviceDiscoverySession),
+        let discovery: *mut AnyObject = msg_send![class!(AVCaptureDeviceDiscoverySession),
             discoverySessionWithDeviceTypes: device_types
             mediaType: media_type
             position: position
@@ -318,15 +318,15 @@ pub fn available_cameras() -> Result<Vec<CameraDescription>, String> {
             return Ok(vec![]);
         }
 
-        let devices: *mut Object = msg_send![discovery, devices];
+        let devices: *mut AnyObject = msg_send![discovery, devices];
         let count: usize = msg_send![devices, count];
         let mut cameras = Vec::with_capacity(count);
 
         for i in 0..count {
-            let device: *mut Object = msg_send![devices, objectAtIndex: i];
+            let device: *mut AnyObject = msg_send![devices, objectAtIndex: i];
 
             // Get unique ID
-            let unique_id: *mut Object = msg_send![device, uniqueID];
+            let unique_id: *mut AnyObject = msg_send![device, uniqueID];
             let cstr: *const std::ffi::c_char = msg_send![unique_id, UTF8String];
             let name = if !cstr.is_null() {
                 std::ffi::CStr::from_ptr(cstr)
@@ -368,8 +368,8 @@ pub fn create_camera(
         }
 
         // Create session
-        let session: *mut Object = msg_send![class!(AVCaptureSession), alloc];
-        let session: *mut Object = msg_send![session, init];
+        let session: *mut AnyObject = msg_send![class!(AVCaptureSession), alloc];
+        let session: *mut AnyObject = msg_send![session, init];
         if session.is_null() {
             return Err("Failed to create AVCaptureSession".into());
         }
@@ -385,10 +385,10 @@ pub fn create_camera(
         }
 
         // Add video input
-        let mut error_ptr: *mut Object = std::ptr::null_mut();
-        let input: *mut Object = msg_send![class!(AVCaptureDeviceInput),
+        let mut error_ptr: *mut AnyObject = std::ptr::null_mut();
+        let input: *mut AnyObject = msg_send![class!(AVCaptureDeviceInput),
             deviceInputWithDevice: device
-            error: &mut error_ptr as *mut *mut Object
+            error: &mut error_ptr as *mut *mut AnyObject
         ];
         if input.is_null() || !error_ptr.is_null() {
             let _: () = msg_send![session, commitConfiguration];
@@ -403,17 +403,17 @@ pub fn create_camera(
         let _: () = msg_send![session, addInput: input];
 
         // Add audio input if requested
-        let mut audio_input: *mut Object = std::ptr::null_mut();
+        let mut audio_input: *mut AnyObject = std::ptr::null_mut();
         if enable_audio {
             let audio_type = nsstring("soun"); // AVMediaTypeAudio
-            let audio_device: *mut Object = msg_send![class!(AVCaptureDevice),
+            let audio_device: *mut AnyObject = msg_send![class!(AVCaptureDevice),
                 defaultDeviceWithMediaType: audio_type
             ];
             if !audio_device.is_null() {
-                let mut audio_err: *mut Object = std::ptr::null_mut();
-                let a_input: *mut Object = msg_send![class!(AVCaptureDeviceInput),
+                let mut audio_err: *mut AnyObject = std::ptr::null_mut();
+                let a_input: *mut AnyObject = msg_send![class!(AVCaptureDeviceInput),
                     deviceInputWithDevice: audio_device
-                    error: &mut audio_err as *mut *mut Object
+                    error: &mut audio_err as *mut *mut AnyObject
                 ];
                 if !a_input.is_null() && audio_err.is_null() {
                     let can_add_audio: BOOL = msg_send![session, canAddInput: a_input];
@@ -426,8 +426,8 @@ pub fn create_camera(
         }
 
         // Add photo output
-        let photo_output: *mut Object = msg_send![class!(AVCapturePhotoOutput), alloc];
-        let photo_output: *mut Object = msg_send![photo_output, init];
+        let photo_output: *mut AnyObject = msg_send![class!(AVCapturePhotoOutput), alloc];
+        let photo_output: *mut AnyObject = msg_send![photo_output, init];
         let can_add_photo: BOOL = msg_send![session, canAddOutput: photo_output];
         if can_add_photo != YES {
             let _: () = msg_send![session, commitConfiguration];
@@ -436,8 +436,8 @@ pub fn create_camera(
         let _: () = msg_send![session, addOutput: photo_output];
 
         // Add video file output
-        let video_output: *mut Object = msg_send![class!(AVCaptureMovieFileOutput), alloc];
-        let video_output: *mut Object = msg_send![video_output, init];
+        let video_output: *mut AnyObject = msg_send![class!(AVCaptureMovieFileOutput), alloc];
+        let video_output: *mut AnyObject = msg_send![video_output, init];
         let can_add_video: BOOL = msg_send![session, canAddOutput: video_output];
         if can_add_video == YES {
             let _: () = msg_send![session, addOutput: video_output];
@@ -495,15 +495,15 @@ pub fn take_picture(handle: &CameraHandle) -> Result<CapturedImage, String> {
             .ok_or("Invalid camera handle")?;
 
         // Create photo settings
-        let settings: *mut Object = msg_send![class!(AVCapturePhotoSettings), photoSettings];
+        let settings: *mut AnyObject = msg_send![class!(AVCapturePhotoSettings), photoSettings];
         if settings.is_null() {
             return Err("Failed to create photo settings".into());
         }
 
         // Create delegate
         let delegate_cls = photo_delegate_class();
-        let delegate: *mut Object = msg_send![delegate_cls, alloc];
-        let delegate: *mut Object = msg_send![delegate, init];
+        let delegate: *mut AnyObject = msg_send![delegate_cls, alloc];
+        let delegate: *mut AnyObject = msg_send![delegate, init];
 
         // Capture
         let _: () = msg_send![state.photo_output,
@@ -540,12 +540,12 @@ pub fn start_video_recording(handle: &CameraHandle) -> Result<(), String> {
         let file_name = format!("video_{}.mov", uuid_str);
         let file_path = std::env::temp_dir().join(&file_name);
         let ns_path = nsstring(&file_path.to_string_lossy());
-        let file_url: *mut Object = msg_send![class!(NSURL), fileURLWithPath: ns_path];
+        let file_url: *mut AnyObject = msg_send![class!(NSURL), fileURLWithPath: ns_path];
 
         // Create delegate
         let delegate_cls = video_delegate_class();
-        let delegate: *mut Object = msg_send![delegate_cls, alloc];
-        let delegate: *mut Object = msg_send![delegate, init];
+        let delegate: *mut AnyObject = msg_send![delegate_cls, alloc];
+        let delegate: *mut AnyObject = msg_send![delegate, init];
 
         let _: () = msg_send![state.video_output,
             startRecordingToOutputFileURL: file_url
@@ -596,9 +596,9 @@ pub fn set_flash_mode(handle: &CameraHandle, mode: FlashMode) -> Result<(), Stri
             if has_torch != YES {
                 return Err("Device does not have a torch".into());
             }
-            let mut err: *mut Object = std::ptr::null_mut();
+            let mut err: *mut AnyObject = std::ptr::null_mut();
             let locked: BOOL =
-                msg_send![device, lockForConfiguration: &mut err as *mut *mut Object];
+                msg_send![device, lockForConfiguration: &mut err as *mut *mut AnyObject];
             if locked != YES {
                 return Err("Failed to lock device for configuration".into());
             }
@@ -610,9 +610,9 @@ pub fn set_flash_mode(handle: &CameraHandle, mode: FlashMode) -> Result<(), Stri
             if has_torch == YES {
                 let torch_mode: i64 = msg_send![device, torchMode];
                 if torch_mode != 0 {
-                    let mut err: *mut Object = std::ptr::null_mut();
+                    let mut err: *mut AnyObject = std::ptr::null_mut();
                     let locked: BOOL =
-                        msg_send![device, lockForConfiguration: &mut err as *mut *mut Object];
+                        msg_send![device, lockForConfiguration: &mut err as *mut *mut AnyObject];
                     if locked == YES {
                         let _: () = msg_send![device, setTorchMode: 0i64]; // AVCaptureTorchModeOff
                         let _: () = msg_send![device, unlockForConfiguration];
@@ -647,8 +647,8 @@ pub fn set_focus_mode(handle: &CameraHandle, mode: FocusMode) -> Result<(), Stri
             return Err("Focus mode not supported".into());
         }
 
-        let mut err: *mut Object = std::ptr::null_mut();
-        let locked: BOOL = msg_send![device, lockForConfiguration: &mut err as *mut *mut Object];
+        let mut err: *mut AnyObject = std::ptr::null_mut();
+        let locked: BOOL = msg_send![device, lockForConfiguration: &mut err as *mut *mut AnyObject];
         if locked != YES {
             return Err("Failed to lock device for configuration".into());
         }
@@ -680,8 +680,8 @@ pub fn set_exposure_mode(handle: &CameraHandle, mode: ExposureMode) -> Result<()
             return Err("Exposure mode not supported".into());
         }
 
-        let mut err: *mut Object = std::ptr::null_mut();
-        let locked: BOOL = msg_send![device, lockForConfiguration: &mut err as *mut *mut Object];
+        let mut err: *mut AnyObject = std::ptr::null_mut();
+        let locked: BOOL = msg_send![device, lockForConfiguration: &mut err as *mut *mut AnyObject];
         if locked != YES {
             return Err("Failed to lock device for configuration".into());
         }
@@ -725,8 +725,8 @@ pub fn set_zoom(handle: &CameraHandle, zoom: f64) -> Result<(), String> {
         let max_zoom: f64 = msg_send![device, maxAvailableVideoZoomFactor];
         let clamped = zoom.max(1.0).min(max_zoom);
 
-        let mut err: *mut Object = std::ptr::null_mut();
-        let locked: BOOL = msg_send![device, lockForConfiguration: &mut err as *mut *mut Object];
+        let mut err: *mut AnyObject = std::ptr::null_mut();
+        let locked: BOOL = msg_send![device, lockForConfiguration: &mut err as *mut *mut AnyObject];
         if locked != YES {
             return Err("Failed to lock device for configuration".into());
         }
@@ -760,10 +760,10 @@ pub fn set_camera(handle: &CameraHandle, camera: &CameraDescription) -> Result<(
         let _: () = msg_send![session, removeInput: state.device_input];
 
         // Create new input
-        let mut error_ptr: *mut Object = std::ptr::null_mut();
-        let new_input: *mut Object = msg_send![class!(AVCaptureDeviceInput),
+        let mut error_ptr: *mut AnyObject = std::ptr::null_mut();
+        let new_input: *mut AnyObject = msg_send![class!(AVCaptureDeviceInput),
             deviceInputWithDevice: new_device
-            error: &mut error_ptr as *mut *mut Object
+            error: &mut error_ptr as *mut *mut AnyObject
         ];
 
         if new_input.is_null() || !error_ptr.is_null() {

--- a/src/packages/camera/ios.rs
+++ b/src/packages/camera/ios.rs
@@ -232,14 +232,7 @@ extern "C" fn video_did_finish(
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-unsafe fn nsstring(s: &str) -> *mut AnyObject {
-    let ns: *mut AnyObject = msg_send![class!(NSString), alloc];
-    msg_send![ns,
-        initWithBytes: s.as_ptr() as *const std::ffi::c_void
-        length: s.len()
-        encoding: 4u64 // NSUTF8StringEncoding
-    ]
-}
+use crate::ios::util::nsstring;
 
 fn resolution_to_preset(resolution: ResolutionPreset) -> &'static str {
     match resolution {

--- a/src/packages/camera/mod.rs
+++ b/src/packages/camera/mod.rs
@@ -124,7 +124,7 @@ fn ensure_factory_registered() {
 ///
 /// Used by `IosPlatformView` to create `AVCaptureVideoPreviewLayer`.
 #[cfg(target_os = "ios")]
-pub fn ios_get_session(id: usize) -> Option<*mut objc::runtime::Object> {
+pub fn ios_get_session(id: usize) -> Option<*mut objc2::runtime::AnyObject> {
     ios::get_session_ptr(id)
 }
 

--- a/src/packages/clipboard/ios.rs
+++ b/src/packages/clipboard/ios.rs
@@ -1,15 +1,15 @@
-use objc::runtime::Object;
-use objc::{class, msg_send, sel, sel_impl};
+use objc2::runtime::AnyObject;
+use objc2::{class, msg_send, sel};
 
 pub fn set_text(text: &str) -> Result<(), String> {
     unsafe {
-        let pasteboard: *mut Object = msg_send![class!(UIPasteboard), generalPasteboard];
+        let pasteboard: *mut AnyObject = msg_send![class!(UIPasteboard), generalPasteboard];
         if pasteboard.is_null() {
             return Err("Failed to get UIPasteboard".into());
         }
 
-        let ns_text: *mut Object = msg_send![class!(NSString), alloc];
-        let ns_text: *mut Object = msg_send![ns_text,
+        let ns_text: *mut AnyObject = msg_send![class!(NSString), alloc];
+        let ns_text: *mut AnyObject = msg_send![ns_text,
             initWithBytes: text.as_ptr() as *const std::ffi::c_void
             length: text.len()
             encoding: 4u64  // NSUTF8StringEncoding
@@ -25,7 +25,7 @@ pub fn set_text(text: &str) -> Result<(), String> {
 
 pub fn get_text() -> Result<Option<String>, String> {
     unsafe {
-        let pasteboard: *mut Object = msg_send![class!(UIPasteboard), generalPasteboard];
+        let pasteboard: *mut AnyObject = msg_send![class!(UIPasteboard), generalPasteboard];
         if pasteboard.is_null() {
             return Err("Failed to get UIPasteboard".into());
         }
@@ -35,7 +35,7 @@ pub fn get_text() -> Result<Option<String>, String> {
             return Ok(None);
         }
 
-        let ns_string: *mut Object = msg_send![pasteboard, string];
+        let ns_string: *mut AnyObject = msg_send![pasteboard, string];
         if ns_string.is_null() {
             return Ok(None);
         }
@@ -55,7 +55,7 @@ pub fn get_text() -> Result<Option<String>, String> {
 
 pub fn has_text() -> Result<bool, String> {
     unsafe {
-        let pasteboard: *mut Object = msg_send![class!(UIPasteboard), generalPasteboard];
+        let pasteboard: *mut AnyObject = msg_send![class!(UIPasteboard), generalPasteboard];
         if pasteboard.is_null() {
             return Err("Failed to get UIPasteboard".into());
         }

--- a/src/packages/contacts/ios.rs
+++ b/src/packages/contacts/ios.rs
@@ -1,5 +1,5 @@
 use super::{Contact, EmailAddress, PhoneNumber};
-use objc2::runtime::AnyObject;
+use objc2::runtime::{AnyObject, Bool};
 use objc2::{class, msg_send, sel};
 
 pub fn get_contacts() -> Result<Vec<Contact>, String> {
@@ -162,20 +162,17 @@ unsafe fn enumerate_contacts(
     error_ptr: *mut *mut AnyObject,
     contacts: &mut Vec<Contact>,
 ) -> bool {
-    // We use block crate to create an Objective-C block for the enumeration callback.
+    // We use block2 to create an Objective-C block for the enumeration callback.
     // The block signature is: void (^)(CNContact *contact, BOOL *stop)
-    use block::ConcreteBlock;
-
     let contacts_ptr = contacts as *mut Vec<Contact>;
 
-    let block = ConcreteBlock::new(move |cn_contact: *mut AnyObject, _stop: *mut bool| {
+    let block = block2::RcBlock::new(move |cn_contact: *mut AnyObject, _stop: *mut Bool| {
         if !cn_contact.is_null() {
-            if let Some(contact) = parse_cn_contact(cn_contact) {
-                (*contacts_ptr).push(contact);
+            if let Some(contact) = unsafe { parse_cn_contact(cn_contact) } {
+                unsafe { (*contacts_ptr).push(contact) };
             }
         }
     });
-    let block = block.copy();
 
     let success: bool = msg_send![store,
         enumerateContactsWithFetchRequest: request

--- a/src/packages/contacts/ios.rs
+++ b/src/packages/contacts/ios.rs
@@ -1,6 +1,6 @@
 use super::{Contact, EmailAddress, PhoneNumber};
-use objc::runtime::Object;
-use objc::{class, msg_send, sel, sel_impl};
+use objc2::runtime::AnyObject;
+use objc2::{class, msg_send, sel};
 
 pub fn get_contacts() -> Result<Vec<Contact>, String> {
     unsafe { fetch_contacts(std::ptr::null_mut()) }
@@ -13,7 +13,7 @@ pub fn search_contacts(query: &str) -> Result<Vec<Contact>, String> {
         if ns_query.is_null() {
             return Err("Failed to create NSString for query".into());
         }
-        let predicate: *mut Object =
+        let predicate: *mut AnyObject =
             msg_send![class!(CNContact), predicateForContactsMatchingName: ns_query];
         if predicate.is_null() {
             return Err("Failed to create search predicate".into());
@@ -30,13 +30,13 @@ pub fn get_contact(id: &str) -> Result<Option<Contact>, String> {
         }
 
         // Create an NSArray with the single identifier
-        let ids_array: *mut Object = msg_send![class!(NSArray), arrayWithObject: ns_id];
+        let ids_array: *mut AnyObject = msg_send![class!(NSArray), arrayWithObject: ns_id];
         if ids_array.is_null() {
             return Err("Failed to create NSArray for identifiers".into());
         }
 
         // CNContact.predicateForContactsWithIdentifiers:
-        let predicate: *mut Object =
+        let predicate: *mut AnyObject =
             msg_send![class!(CNContact), predicateForContactsWithIdentifiers: ids_array];
         if predicate.is_null() {
             return Err("Failed to create identifier predicate".into());
@@ -50,9 +50,9 @@ pub fn get_contact(id: &str) -> Result<Option<Contact>, String> {
 /// Fetch contacts from CNContactStore, optionally filtered by a predicate.
 ///
 /// If `predicate` is null, all contacts are returned.
-unsafe fn fetch_contacts(predicate: *mut Object) -> Result<Vec<Contact>, String> {
-    let store: *mut Object = msg_send![class!(CNContactStore), alloc];
-    let store: *mut Object = msg_send![store, init];
+unsafe fn fetch_contacts(predicate: *mut AnyObject) -> Result<Vec<Contact>, String> {
+    let store: *mut AnyObject = msg_send![class!(CNContactStore), alloc];
+    let store: *mut AnyObject = msg_send![store, init];
     if store.is_null() {
         return Err("Failed to create CNContactStore".into());
     }
@@ -65,8 +65,8 @@ unsafe fn fetch_contacts(predicate: *mut Object) -> Result<Vec<Contact>, String>
     }
 
     // Create CNContactFetchRequest
-    let request: *mut Object = msg_send![class!(CNContactFetchRequest), alloc];
-    let request: *mut Object = msg_send![request, initWithKeysToFetch: keys];
+    let request: *mut AnyObject = msg_send![class!(CNContactFetchRequest), alloc];
+    let request: *mut AnyObject = msg_send![request, initWithKeysToFetch: keys];
     if request.is_null() {
         let _: () = msg_send![store, release];
         return Err("Failed to create CNContactFetchRequest".into());
@@ -81,7 +81,7 @@ unsafe fn fetch_contacts(predicate: *mut Object) -> Result<Vec<Contact>, String>
     let _: () = msg_send![request, setSortOrder: 1i64]; // CNContactSortOrderGivenName = 1
 
     // Enumerate contacts
-    let contacts_array: *mut Object = msg_send![class!(NSMutableArray), new];
+    let contacts_array: *mut AnyObject = msg_send![class!(NSMutableArray), new];
     if contacts_array.is_null() {
         let _: () = msg_send![request, release];
         let _: () = msg_send![store, release];
@@ -100,15 +100,15 @@ unsafe fn fetch_contacts(predicate: *mut Object) -> Result<Vec<Contact>, String>
     if predicate.is_null() {
         // For all contacts, we need to use enumerateContactsWithFetchRequest:error:usingBlock:
         // This requires a block. We'll use the block crate.
-        let error: *mut Object = std::ptr::null_mut();
-        let error_ptr: *mut *mut Object = &error as *const _ as *mut *mut Object;
+        let error: *mut AnyObject = std::ptr::null_mut();
+        let error_ptr: *mut *mut AnyObject = &error as *const _ as *mut *mut AnyObject;
 
         // Use a simpler approach: fetch contacts matching an empty name predicate
         // Actually CNContact doesn't have such a predicate. Let's use the block-based enumerate.
         let success: bool = enumerate_contacts(store, request, error_ptr, &mut contacts);
 
         if !success && !error.is_null() {
-            let desc: *mut Object = msg_send![error, localizedDescription];
+            let desc: *mut AnyObject = msg_send![error, localizedDescription];
             let err_msg = nsstring_to_string(desc);
             let _: () = msg_send![contacts_array, release];
             let _: () = msg_send![request, release];
@@ -117,10 +117,10 @@ unsafe fn fetch_contacts(predicate: *mut Object) -> Result<Vec<Contact>, String>
         }
     } else {
         // Use unifiedContactsMatchingPredicate:keysToFetch:error:
-        let error: *mut Object = std::ptr::null_mut();
-        let error_ptr: *mut *mut Object = &error as *const _ as *mut *mut Object;
+        let error: *mut AnyObject = std::ptr::null_mut();
+        let error_ptr: *mut *mut AnyObject = &error as *const _ as *mut *mut AnyObject;
 
-        let results: *mut Object = msg_send![store,
+        let results: *mut AnyObject = msg_send![store,
             unifiedContactsMatchingPredicate: predicate
             keysToFetch: keys
             error: error_ptr
@@ -128,7 +128,7 @@ unsafe fn fetch_contacts(predicate: *mut Object) -> Result<Vec<Contact>, String>
 
         if results.is_null() {
             let err_msg = if !error.is_null() {
-                let desc: *mut Object = msg_send![error, localizedDescription];
+                let desc: *mut AnyObject = msg_send![error, localizedDescription];
                 nsstring_to_string(desc)
             } else {
                 "Unknown error".to_owned()
@@ -141,7 +141,7 @@ unsafe fn fetch_contacts(predicate: *mut Object) -> Result<Vec<Contact>, String>
 
         let count: usize = msg_send![results, count];
         for i in 0..count {
-            let cn_contact: *mut Object = msg_send![results, objectAtIndex: i];
+            let cn_contact: *mut AnyObject = msg_send![results, objectAtIndex: i];
             if let Some(contact) = parse_cn_contact(cn_contact) {
                 contacts.push(contact);
             }
@@ -157,9 +157,9 @@ unsafe fn fetch_contacts(predicate: *mut Object) -> Result<Vec<Contact>, String>
 
 /// Enumerate all contacts using a fetch request and a block callback.
 unsafe fn enumerate_contacts(
-    store: *mut Object,
-    request: *mut Object,
-    error_ptr: *mut *mut Object,
+    store: *mut AnyObject,
+    request: *mut AnyObject,
+    error_ptr: *mut *mut AnyObject,
     contacts: &mut Vec<Contact>,
 ) -> bool {
     // We use block crate to create an Objective-C block for the enumeration callback.
@@ -168,7 +168,7 @@ unsafe fn enumerate_contacts(
 
     let contacts_ptr = contacts as *mut Vec<Contact>;
 
-    let block = ConcreteBlock::new(move |cn_contact: *mut Object, _stop: *mut bool| {
+    let block = ConcreteBlock::new(move |cn_contact: *mut AnyObject, _stop: *mut bool| {
         if !cn_contact.is_null() {
             if let Some(contact) = parse_cn_contact(cn_contact) {
                 (*contacts_ptr).push(contact);
@@ -187,18 +187,18 @@ unsafe fn enumerate_contacts(
 }
 
 /// Parse a CNContact object into our Contact struct.
-unsafe fn parse_cn_contact(cn_contact: *mut Object) -> Option<Contact> {
+unsafe fn parse_cn_contact(cn_contact: *mut AnyObject) -> Option<Contact> {
     if cn_contact.is_null() {
         return None;
     }
 
-    let identifier: *mut Object = msg_send![cn_contact, identifier];
+    let identifier: *mut AnyObject = msg_send![cn_contact, identifier];
     let id = nsstring_to_string(identifier);
 
-    let given_name_ns: *mut Object = msg_send![cn_contact, givenName];
+    let given_name_ns: *mut AnyObject = msg_send![cn_contact, givenName];
     let given_name = nsstring_to_string(given_name_ns);
 
-    let family_name_ns: *mut Object = msg_send![cn_contact, familyName];
+    let family_name_ns: *mut AnyObject = msg_send![cn_contact, familyName];
     let family_name = nsstring_to_string(family_name_ns);
 
     // Build display name from given + family
@@ -213,11 +213,11 @@ unsafe fn parse_cn_contact(cn_contact: *mut Object) -> Option<Contact> {
     };
 
     // Phone numbers: NSArray<CNLabeledValue<CNPhoneNumber *> *>
-    let phone_numbers: *mut Object = msg_send![cn_contact, phoneNumbers];
+    let phone_numbers: *mut AnyObject = msg_send![cn_contact, phoneNumbers];
     let phones = parse_phone_numbers(phone_numbers);
 
     // Email addresses: NSArray<CNLabeledValue<NSString *> *>
-    let email_addresses: *mut Object = msg_send![cn_contact, emailAddresses];
+    let email_addresses: *mut AnyObject = msg_send![cn_contact, emailAddresses];
     let emails = parse_email_addresses(email_addresses);
 
     Some(Contact {
@@ -231,7 +231,7 @@ unsafe fn parse_cn_contact(cn_contact: *mut Object) -> Option<Contact> {
 }
 
 /// Parse an NSArray of CNLabeledValue<CNPhoneNumber> into phone number entries.
-unsafe fn parse_phone_numbers(array: *mut Object) -> Vec<PhoneNumber> {
+unsafe fn parse_phone_numbers(array: *mut AnyObject) -> Vec<PhoneNumber> {
     if array.is_null() {
         return Vec::new();
     }
@@ -240,27 +240,27 @@ unsafe fn parse_phone_numbers(array: *mut Object) -> Vec<PhoneNumber> {
     let mut phones = Vec::with_capacity(count);
 
     for i in 0..count {
-        let labeled_value: *mut Object = msg_send![array, objectAtIndex: i];
+        let labeled_value: *mut AnyObject = msg_send![array, objectAtIndex: i];
         if labeled_value.is_null() {
             continue;
         }
 
         // Get the CNPhoneNumber value
-        let phone_number_obj: *mut Object = msg_send![labeled_value, value];
+        let phone_number_obj: *mut AnyObject = msg_send![labeled_value, value];
         if phone_number_obj.is_null() {
             continue;
         }
 
-        let number_ns: *mut Object = msg_send![phone_number_obj, stringValue];
+        let number_ns: *mut AnyObject = msg_send![phone_number_obj, stringValue];
         let number = nsstring_to_string(number_ns);
 
         // Get label
-        let label_ns: *mut Object = msg_send![labeled_value, label];
+        let label_ns: *mut AnyObject = msg_send![labeled_value, label];
         let label = if label_ns.is_null() {
             "other".to_owned()
         } else {
             // Localize the label
-            let localized: *mut Object =
+            let localized: *mut AnyObject =
                 msg_send![class!(CNLabeledValue), localizedStringForLabel: label_ns];
             if localized.is_null() {
                 nsstring_to_string(label_ns)
@@ -276,7 +276,7 @@ unsafe fn parse_phone_numbers(array: *mut Object) -> Vec<PhoneNumber> {
 }
 
 /// Parse an NSArray of CNLabeledValue<NSString> into email address entries.
-unsafe fn parse_email_addresses(array: *mut Object) -> Vec<EmailAddress> {
+unsafe fn parse_email_addresses(array: *mut AnyObject) -> Vec<EmailAddress> {
     if array.is_null() {
         return Vec::new();
     }
@@ -285,19 +285,19 @@ unsafe fn parse_email_addresses(array: *mut Object) -> Vec<EmailAddress> {
     let mut emails = Vec::with_capacity(count);
 
     for i in 0..count {
-        let labeled_value: *mut Object = msg_send![array, objectAtIndex: i];
+        let labeled_value: *mut AnyObject = msg_send![array, objectAtIndex: i];
         if labeled_value.is_null() {
             continue;
         }
 
-        let address_ns: *mut Object = msg_send![labeled_value, value];
+        let address_ns: *mut AnyObject = msg_send![labeled_value, value];
         let address = nsstring_to_string(address_ns);
 
-        let label_ns: *mut Object = msg_send![labeled_value, label];
+        let label_ns: *mut AnyObject = msg_send![labeled_value, label];
         let label = if label_ns.is_null() {
             "other".to_owned()
         } else {
-            let localized: *mut Object =
+            let localized: *mut AnyObject =
                 msg_send![class!(CNLabeledValue), localizedStringForLabel: label_ns];
             if localized.is_null() {
                 nsstring_to_string(label_ns)
@@ -313,7 +313,7 @@ unsafe fn parse_email_addresses(array: *mut Object) -> Vec<EmailAddress> {
 }
 
 /// Create the NSArray of CNContact keys to fetch.
-unsafe fn create_fetch_keys() -> *mut Object {
+unsafe fn create_fetch_keys() -> *mut AnyObject {
     // We need CNContactIdentifierKey, CNContactGivenNameKey, CNContactFamilyNameKey,
     // CNContactPhoneNumbersKey, CNContactEmailAddressesKey
     let key_identifier = new_nsstring("identifier");
@@ -330,7 +330,7 @@ unsafe fn create_fetch_keys() -> *mut Object {
         key_email_addresses,
     ];
 
-    let array: *mut Object = msg_send![class!(NSArray),
+    let array: *mut AnyObject = msg_send![class!(NSArray),
         arrayWithObjects: objects.as_ptr()
         count: objects.len()
     ];
@@ -339,9 +339,9 @@ unsafe fn create_fetch_keys() -> *mut Object {
 }
 
 /// Create an NSString from a Rust &str.
-unsafe fn new_nsstring(s: &str) -> *mut Object {
-    let ns: *mut Object = msg_send![class!(NSString), alloc];
-    let ns: *mut Object = msg_send![ns,
+unsafe fn new_nsstring(s: &str) -> *mut AnyObject {
+    let ns: *mut AnyObject = msg_send![class!(NSString), alloc];
+    let ns: *mut AnyObject = msg_send![ns,
         initWithBytes: s.as_ptr() as *const std::ffi::c_void
         length: s.len()
         encoding: 4u64  // NSUTF8StringEncoding
@@ -350,7 +350,7 @@ unsafe fn new_nsstring(s: &str) -> *mut Object {
 }
 
 /// Convert an NSString to a Rust String.
-unsafe fn nsstring_to_string(ns: *mut Object) -> String {
+unsafe fn nsstring_to_string(ns: *mut AnyObject) -> String {
     if ns.is_null() {
         return String::new();
     }

--- a/src/packages/device_info/ios.rs
+++ b/src/packages/device_info/ios.rs
@@ -1,12 +1,12 @@
 use super::DeviceInfo;
-use objc::runtime::Object;
-use objc::{class, msg_send, sel, sel_impl};
+use objc2::runtime::AnyObject;
+use objc2::{class, msg_send, sel};
 use std::ffi::CStr;
 
 pub fn get_device_info() -> Result<DeviceInfo, String> {
     unsafe {
         // UIDevice.currentDevice
-        let device: *mut Object = msg_send![class!(UIDevice), currentDevice];
+        let device: *mut AnyObject = msg_send![class!(UIDevice), currentDevice];
         if device.is_null() {
             return Err("Failed to get UIDevice.currentDevice".into());
         }
@@ -52,7 +52,7 @@ fn is_simulator() -> bool {
     model == "x86_64" || model == "arm64" || model.contains("simulator")
 }
 
-unsafe fn nsstring_to_string(ns: *mut Object) -> String {
+unsafe fn nsstring_to_string(ns: *mut AnyObject) -> String {
     if ns.is_null() {
         return String::new();
     }

--- a/src/packages/file_selector/ios.rs
+++ b/src/packages/file_selector/ios.rs
@@ -1,7 +1,7 @@
 use super::{OpenFileOptions, SaveFileOptions, SelectedFile, TypeGroup};
-use objc::declare::ClassDecl;
-use objc::runtime::{Class, Object, Sel, BOOL, YES};
-use objc::{class, msg_send, sel, sel_impl};
+use objc2::ffi::{BOOL, YES};
+use objc2::runtime::{AnyClass, AnyObject, ClassBuilder, Sel};
+use objc2::{class, msg_send, sel};
 use std::sync::{mpsc, Mutex, Once};
 
 #[link(name = "UIKit", kind = "framework")]
@@ -29,43 +29,43 @@ fn send_result(paths: Vec<String>) {
 // ── ObjC delegate class ─────────────────────────────────────────────────────
 
 static REGISTER_DELEGATE: Once = Once::new();
-static mut DELEGATE_CLASS: *const Class = std::ptr::null();
+static mut DELEGATE_CLASS: *const AnyClass = std::ptr::null();
 
-fn delegate_class() -> &'static Class {
+fn delegate_class() -> &'static AnyClass {
     REGISTER_DELEGATE.call_once(|| {
         let superclass = class!(NSObject);
-        let mut decl = ClassDecl::new("GpuiDocumentPickerDelegate", superclass).unwrap();
+        let mut decl = ClassBuilder::new("GpuiDocumentPickerDelegate", superclass).unwrap();
 
         unsafe {
             // documentPicker:didPickDocumentsAtURLs:
             decl.add_method(
                 sel!(documentPicker:didPickDocumentsAtURLs:),
-                did_pick_documents as extern "C" fn(&Object, Sel, *mut Object, *mut Object),
+                did_pick_documents as extern "C" fn(&AnyObject, Sel, *mut AnyObject, *mut AnyObject),
             );
             // documentPickerWasCancelled:
             decl.add_method(
                 sel!(documentPickerWasCancelled:),
-                did_cancel as extern "C" fn(&Object, Sel, *mut Object),
+                did_cancel as extern "C" fn(&AnyObject, Sel, *mut AnyObject),
             );
         }
 
-        unsafe { DELEGATE_CLASS = decl.register() };
+        unsafe { DELEGATE_CLASS = decl.register() as *const AnyClass };
     });
     unsafe { &*DELEGATE_CLASS }
 }
 
 extern "C" fn did_pick_documents(
-    _this: &Object,
+    _this: &AnyObject,
     _sel: Sel,
-    _controller: *mut Object,
-    urls: *mut Object,
+    _controller: *mut AnyObject,
+    urls: *mut AnyObject,
 ) {
     unsafe {
         let count: usize = msg_send![urls, count];
         let mut paths = Vec::with_capacity(count);
         for i in 0..count {
-            let url: *mut Object = msg_send![urls, objectAtIndex: i];
-            let abs_string: *mut Object = msg_send![url, absoluteString];
+            let url: *mut AnyObject = msg_send![urls, objectAtIndex: i];
+            let abs_string: *mut AnyObject = msg_send![url, absoluteString];
             if !abs_string.is_null() {
                 let cstr: *const std::ffi::c_char = msg_send![abs_string, UTF8String];
                 if !cstr.is_null() {
@@ -78,14 +78,14 @@ extern "C" fn did_pick_documents(
             }
         }
         // Dismiss the picker
-        let _: () = msg_send![_controller, dismissViewControllerAnimated: YES completion: std::ptr::null::<Object>()];
+        let _: () = msg_send![_controller, dismissViewControllerAnimated: YES completion: std::ptr::null::<AnyObject>()];
         send_result(paths);
     }
 }
 
-extern "C" fn did_cancel(_this: &Object, _sel: Sel, controller: *mut Object) {
+extern "C" fn did_cancel(_this: &AnyObject, _sel: Sel, controller: *mut AnyObject) {
     unsafe {
-        let _: () = msg_send![controller, dismissViewControllerAnimated: YES completion: std::ptr::null::<Object>()];
+        let _: () = msg_send![controller, dismissViewControllerAnimated: YES completion: std::ptr::null::<AnyObject>()];
     }
     send_result(vec![]);
 }
@@ -93,8 +93,8 @@ extern "C" fn did_cancel(_this: &Object, _sel: Sel, controller: *mut Object) {
 // ── UTType helpers ──────────────────────────────────────────────────────────
 
 /// Convert a TypeGroup into an NSArray of UTType objects.
-unsafe fn type_group_to_uttypes(group: &TypeGroup) -> *mut Object {
-    let mut types: Vec<*mut Object> = Vec::new();
+unsafe fn type_group_to_uttypes(group: &TypeGroup) -> *mut AnyObject {
+    let mut types: Vec<*mut AnyObject> = Vec::new();
 
     // Prefer explicit UTIs
     for uti in &group.utis {
@@ -135,23 +135,23 @@ unsafe fn type_group_to_uttypes(group: &TypeGroup) -> *mut Object {
     nsarray_from_objects(&types)
 }
 
-unsafe fn uttype_from_identifier(ident: &str) -> *mut Object {
+unsafe fn uttype_from_identifier(ident: &str) -> *mut AnyObject {
     let ns_ident = nsstring(ident);
     msg_send![class!(UTType), typeWithIdentifier: ns_ident]
 }
 
-unsafe fn uttype_from_extension(ext: &str) -> *mut Object {
+unsafe fn uttype_from_extension(ext: &str) -> *mut AnyObject {
     let ns_ext = nsstring(ext);
     msg_send![class!(UTType), typeWithFilenameExtension: ns_ext]
 }
 
-unsafe fn uttype_from_mime(mime: &str) -> *mut Object {
+unsafe fn uttype_from_mime(mime: &str) -> *mut AnyObject {
     let ns_mime = nsstring(mime);
     msg_send![class!(UTType), typeWithMIMEType: ns_mime]
 }
 
-unsafe fn nsstring(s: &str) -> *mut Object {
-    let ns: *mut Object = msg_send![class!(NSString), alloc];
+unsafe fn nsstring(s: &str) -> *mut AnyObject {
+    let ns: *mut AnyObject = msg_send![class!(NSString), alloc];
     msg_send![ns,
         initWithBytes: s.as_ptr() as *const std::ffi::c_void
         length: s.len()
@@ -159,7 +159,7 @@ unsafe fn nsstring(s: &str) -> *mut Object {
     ]
 }
 
-unsafe fn nsarray_from_objects(objects: &[*mut Object]) -> *mut Object {
+unsafe fn nsarray_from_objects(objects: &[*mut AnyObject]) -> *mut AnyObject {
     msg_send![class!(NSArray),
         arrayWithObjects: objects.as_ptr()
         count: objects.len()
@@ -168,20 +168,20 @@ unsafe fn nsarray_from_objects(objects: &[*mut Object]) -> *mut Object {
 
 // ── Presentation helper ─────────────────────────────────────────────────────
 
-unsafe fn present_picker(picker: *mut Object) -> Result<(), String> {
-    let app: *mut Object = msg_send![class!(UIApplication), sharedApplication];
-    let key_window: *mut Object = msg_send![app, keyWindow];
+unsafe fn present_picker(picker: *mut AnyObject) -> Result<(), String> {
+    let app: *mut AnyObject = msg_send![class!(UIApplication), sharedApplication];
+    let key_window: *mut AnyObject = msg_send![app, keyWindow];
     if key_window.is_null() {
         return Err("No key window available".into());
     }
-    let root_vc: *mut Object = msg_send![key_window, rootViewController];
+    let root_vc: *mut AnyObject = msg_send![key_window, rootViewController];
     if root_vc.is_null() {
         return Err("No root view controller".into());
     }
     let _: () = msg_send![root_vc,
         presentViewController: picker
         animated: YES
-        completion: std::ptr::null::<Object>()
+        completion: std::ptr::null::<AnyObject>()
     ];
     Ok(())
 }
@@ -211,12 +211,12 @@ pub fn open_file(options: &OpenFileOptions) -> Result<Option<SelectedFile>, Stri
             nsarray_from_objects(&[ut])
         } else {
             // Merge all type groups into one array
-            let mut all_types: Vec<*mut Object> = Vec::new();
+            let mut all_types: Vec<*mut AnyObject> = Vec::new();
             for group in &options.accept_type_groups {
                 let arr = type_group_to_uttypes(group);
                 let count: usize = msg_send![arr, count];
                 for i in 0..count {
-                    let obj: *mut Object = msg_send![arr, objectAtIndex: i];
+                    let obj: *mut AnyObject = msg_send![arr, objectAtIndex: i];
                     all_types.push(obj);
                 }
             }
@@ -225,8 +225,8 @@ pub fn open_file(options: &OpenFileOptions) -> Result<Option<SelectedFile>, Stri
 
         // UIDocumentPickerViewController *picker =
         //   [[UIDocumentPickerViewController alloc] initForOpeningContentTypes:types];
-        let picker: *mut Object = msg_send![class!(UIDocumentPickerViewController), alloc];
-        let picker: *mut Object = msg_send![picker, initForOpeningContentTypes: content_types];
+        let picker: *mut AnyObject = msg_send![class!(UIDocumentPickerViewController), alloc];
+        let picker: *mut AnyObject = msg_send![picker, initForOpeningContentTypes: content_types];
         if picker.is_null() {
             return Err("Failed to create UIDocumentPickerViewController".into());
         }
@@ -235,8 +235,8 @@ pub fn open_file(options: &OpenFileOptions) -> Result<Option<SelectedFile>, Stri
 
         // Set delegate
         let delegate_cls = delegate_class();
-        let delegate: *mut Object = msg_send![delegate_cls, alloc];
-        let delegate: *mut Object = msg_send![delegate, init];
+        let delegate: *mut AnyObject = msg_send![delegate_cls, alloc];
+        let delegate: *mut AnyObject = msg_send![delegate, init];
         let _: () = msg_send![picker, setDelegate: delegate];
 
         present_picker(picker)?;
@@ -257,20 +257,20 @@ pub fn open_files(options: &OpenFileOptions) -> Result<Vec<SelectedFile>, String
             let ut = uttype_from_identifier("public.item");
             nsarray_from_objects(&[ut])
         } else {
-            let mut all_types: Vec<*mut Object> = Vec::new();
+            let mut all_types: Vec<*mut AnyObject> = Vec::new();
             for group in &options.accept_type_groups {
                 let arr = type_group_to_uttypes(group);
                 let count: usize = msg_send![arr, count];
                 for i in 0..count {
-                    let obj: *mut Object = msg_send![arr, objectAtIndex: i];
+                    let obj: *mut AnyObject = msg_send![arr, objectAtIndex: i];
                     all_types.push(obj);
                 }
             }
             nsarray_from_objects(&all_types)
         };
 
-        let picker: *mut Object = msg_send![class!(UIDocumentPickerViewController), alloc];
-        let picker: *mut Object = msg_send![picker, initForOpeningContentTypes: content_types];
+        let picker: *mut AnyObject = msg_send![class!(UIDocumentPickerViewController), alloc];
+        let picker: *mut AnyObject = msg_send![picker, initForOpeningContentTypes: content_types];
         if picker.is_null() {
             return Err("Failed to create UIDocumentPickerViewController".into());
         }
@@ -278,8 +278,8 @@ pub fn open_files(options: &OpenFileOptions) -> Result<Vec<SelectedFile>, String
         let _: () = msg_send![picker, setAllowsMultipleSelection: YES];
 
         let delegate_cls = delegate_class();
-        let delegate: *mut Object = msg_send![delegate_cls, alloc];
-        let delegate: *mut Object = msg_send![delegate, init];
+        let delegate: *mut AnyObject = msg_send![delegate_cls, alloc];
+        let delegate: *mut AnyObject = msg_send![delegate, init];
         let _: () = msg_send![picker, setDelegate: delegate];
 
         present_picker(picker)?;
@@ -301,12 +301,12 @@ pub fn get_save_path(options: &SaveFileOptions) -> Result<Option<String>, String
             let ut = uttype_from_identifier("public.data");
             nsarray_from_objects(&[ut])
         } else {
-            let mut all_types: Vec<*mut Object> = Vec::new();
+            let mut all_types: Vec<*mut AnyObject> = Vec::new();
             for group in &options.accept_type_groups {
                 let arr = type_group_to_uttypes(group);
                 let count: usize = msg_send![arr, count];
                 for i in 0..count {
-                    let obj: *mut Object = msg_send![arr, objectAtIndex: i];
+                    let obj: *mut AnyObject = msg_send![arr, objectAtIndex: i];
                     all_types.push(obj);
                 }
             }
@@ -314,15 +314,15 @@ pub fn get_save_path(options: &SaveFileOptions) -> Result<Option<String>, String
         };
 
         // Use "move to" mode which lets user pick a save location
-        let picker: *mut Object = msg_send![class!(UIDocumentPickerViewController), alloc];
-        let picker: *mut Object = msg_send![picker, initForOpeningContentTypes: content_types];
+        let picker: *mut AnyObject = msg_send![class!(UIDocumentPickerViewController), alloc];
+        let picker: *mut AnyObject = msg_send![picker, initForOpeningContentTypes: content_types];
         if picker.is_null() {
             return Err("Failed to create UIDocumentPickerViewController".into());
         }
 
         let delegate_cls = delegate_class();
-        let delegate: *mut Object = msg_send![delegate_cls, alloc];
-        let delegate: *mut Object = msg_send![delegate, init];
+        let delegate: *mut AnyObject = msg_send![delegate_cls, alloc];
+        let delegate: *mut AnyObject = msg_send![delegate, init];
         let _: () = msg_send![picker, setDelegate: delegate];
 
         present_picker(picker)?;
@@ -348,8 +348,8 @@ pub fn get_directory_path(initial_directory: Option<&str>) -> Result<Option<Stri
         let folder_type = uttype_from_identifier("public.folder");
         let content_types = nsarray_from_objects(&[folder_type]);
 
-        let picker: *mut Object = msg_send![class!(UIDocumentPickerViewController), alloc];
-        let picker: *mut Object = msg_send![picker, initForOpeningContentTypes: content_types];
+        let picker: *mut AnyObject = msg_send![class!(UIDocumentPickerViewController), alloc];
+        let picker: *mut AnyObject = msg_send![picker, initForOpeningContentTypes: content_types];
         if picker.is_null() {
             return Err("Failed to create UIDocumentPickerViewController".into());
         }
@@ -357,7 +357,7 @@ pub fn get_directory_path(initial_directory: Option<&str>) -> Result<Option<Stri
         // Set initial directory if provided
         if let Some(dir) = initial_directory {
             let ns_dir = nsstring(dir);
-            let dir_url: *mut Object =
+            let dir_url: *mut AnyObject =
                 msg_send![class!(NSURL), fileURLWithPath: ns_dir isDirectory: YES];
             if !dir_url.is_null() {
                 let _: () = msg_send![picker, setDirectoryURL: dir_url];
@@ -365,8 +365,8 @@ pub fn get_directory_path(initial_directory: Option<&str>) -> Result<Option<Stri
         }
 
         let delegate_cls = delegate_class();
-        let delegate: *mut Object = msg_send![delegate_cls, alloc];
-        let delegate: *mut Object = msg_send![delegate, init];
+        let delegate: *mut AnyObject = msg_send![delegate_cls, alloc];
+        let delegate: *mut AnyObject = msg_send![delegate, init];
         let _: () = msg_send![picker, setDelegate: delegate];
 
         present_picker(picker)?;

--- a/src/packages/file_selector/ios.rs
+++ b/src/packages/file_selector/ios.rs
@@ -40,7 +40,8 @@ fn delegate_class() -> &'static AnyClass {
             // documentPicker:didPickDocumentsAtURLs:
             decl.add_method(
                 sel!(documentPicker:didPickDocumentsAtURLs:),
-                did_pick_documents as unsafe extern "C" fn(*mut AnyObject, Sel, *mut AnyObject, *mut AnyObject),
+                did_pick_documents
+                    as unsafe extern "C" fn(*mut AnyObject, Sel, *mut AnyObject, *mut AnyObject),
             );
             // documentPickerWasCancelled:
             decl.add_method(
@@ -227,7 +228,8 @@ pub fn open_file(options: &OpenFileOptions) -> Result<Option<SelectedFile>, Stri
             return Err("Failed to create UIDocumentPickerViewController".into());
         }
 
-        let _: () = msg_send![picker, setAllowsMultipleSelection: objc2::runtime::Bool::from(false)];
+        let _: () =
+            msg_send![picker, setAllowsMultipleSelection: objc2::runtime::Bool::from(false)];
 
         // Set delegate
         let delegate_cls = delegate_class();

--- a/src/packages/file_selector/ios.rs
+++ b/src/packages/file_selector/ios.rs
@@ -34,18 +34,18 @@ static mut DELEGATE_CLASS: *const AnyClass = std::ptr::null();
 fn delegate_class() -> &'static AnyClass {
     REGISTER_DELEGATE.call_once(|| {
         let superclass = class!(NSObject);
-        let mut decl = ClassBuilder::new("GpuiDocumentPickerDelegate", superclass).unwrap();
+        let mut decl = ClassBuilder::new(c"GpuiDocumentPickerDelegate", superclass).unwrap();
 
         unsafe {
             // documentPicker:didPickDocumentsAtURLs:
             decl.add_method(
                 sel!(documentPicker:didPickDocumentsAtURLs:),
-                did_pick_documents as extern "C" fn(&AnyObject, Sel, *mut AnyObject, *mut AnyObject),
+                did_pick_documents as unsafe extern "C" fn(*mut AnyObject, Sel, *mut AnyObject, *mut AnyObject),
             );
             // documentPickerWasCancelled:
             decl.add_method(
                 sel!(documentPickerWasCancelled:),
-                did_cancel as extern "C" fn(&AnyObject, Sel, *mut AnyObject),
+                did_cancel as unsafe extern "C" fn(*mut AnyObject, Sel, *mut AnyObject),
             );
         }
 
@@ -54,39 +54,35 @@ fn delegate_class() -> &'static AnyClass {
     unsafe { &*DELEGATE_CLASS }
 }
 
-extern "C" fn did_pick_documents(
-    _this: &AnyObject,
+unsafe extern "C" fn did_pick_documents(
+    _this: *mut AnyObject,
     _sel: Sel,
     _controller: *mut AnyObject,
     urls: *mut AnyObject,
 ) {
-    unsafe {
-        let count: usize = msg_send![urls, count];
-        let mut paths = Vec::with_capacity(count);
-        for i in 0..count {
-            let url: *mut AnyObject = msg_send![urls, objectAtIndex: i];
-            let abs_string: *mut AnyObject = msg_send![url, absoluteString];
-            if !abs_string.is_null() {
-                let cstr: *const std::ffi::c_char = msg_send![abs_string, UTF8String];
-                if !cstr.is_null() {
-                    paths.push(
-                        std::ffi::CStr::from_ptr(cstr)
-                            .to_string_lossy()
-                            .into_owned(),
-                    );
-                }
+    let count: usize = msg_send![urls, count];
+    let mut paths = Vec::with_capacity(count);
+    for i in 0..count {
+        let url: *mut AnyObject = msg_send![urls, objectAtIndex: i];
+        let abs_string: *mut AnyObject = msg_send![url, absoluteString];
+        if !abs_string.is_null() {
+            let cstr: *const std::ffi::c_char = msg_send![abs_string, UTF8String];
+            if !cstr.is_null() {
+                paths.push(
+                    std::ffi::CStr::from_ptr(cstr)
+                        .to_string_lossy()
+                        .into_owned(),
+                );
             }
         }
-        // Dismiss the picker
-        let _: () = msg_send![_controller, dismissViewControllerAnimated: YES completion: std::ptr::null::<AnyObject>()];
-        send_result(paths);
     }
+    // Dismiss the picker
+    let _: () = msg_send![_controller, dismissViewControllerAnimated: YES completion: std::ptr::null::<AnyObject>()];
+    send_result(paths);
 }
 
-extern "C" fn did_cancel(_this: &AnyObject, _sel: Sel, controller: *mut AnyObject) {
-    unsafe {
-        let _: () = msg_send![controller, dismissViewControllerAnimated: YES completion: std::ptr::null::<AnyObject>()];
-    }
+unsafe extern "C" fn did_cancel(_this: *mut AnyObject, _sel: Sel, controller: *mut AnyObject) {
+    let _: () = msg_send![controller, dismissViewControllerAnimated: YES completion: std::ptr::null::<AnyObject>()];
     send_result(vec![]);
 }
 
@@ -231,7 +227,7 @@ pub fn open_file(options: &OpenFileOptions) -> Result<Option<SelectedFile>, Stri
             return Err("Failed to create UIDocumentPickerViewController".into());
         }
 
-        let _: () = msg_send![picker, setAllowsMultipleSelection: false as BOOL];
+        let _: () = msg_send![picker, setAllowsMultipleSelection: objc2::runtime::Bool::from(false)];
 
         // Set delegate
         let delegate_cls = delegate_class();

--- a/src/packages/file_selector/ios.rs
+++ b/src/packages/file_selector/ios.rs
@@ -147,14 +147,7 @@ unsafe fn uttype_from_mime(mime: &str) -> *mut AnyObject {
     msg_send![class!(UTType), typeWithMIMEType: ns_mime]
 }
 
-unsafe fn nsstring(s: &str) -> *mut AnyObject {
-    let ns: *mut AnyObject = msg_send![class!(NSString), alloc];
-    msg_send![ns,
-        initWithBytes: s.as_ptr() as *const std::ffi::c_void
-        length: s.len()
-        encoding: 4u64 // NSUTF8StringEncoding
-    ]
-}
+use crate::ios::util::nsstring;
 
 unsafe fn nsarray_from_objects(objects: &[*mut AnyObject]) -> *mut AnyObject {
     msg_send![class!(NSArray),

--- a/src/packages/image_picker/ios.rs
+++ b/src/packages/image_picker/ios.rs
@@ -229,14 +229,7 @@ unsafe fn uiimage_jpeg_representation(image: *mut AnyObject, quality: f64) -> *m
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-unsafe fn nsstring(s: &str) -> *mut AnyObject {
-    let ns: *mut AnyObject = msg_send![class!(NSString), alloc];
-    msg_send![ns,
-        initWithBytes: s.as_ptr() as *const std::ffi::c_void
-        length: s.len()
-        encoding: 4u64 // NSUTF8StringEncoding
-    ]
-}
+use crate::ios::util::nsstring;
 
 unsafe fn present_vc(vc: *mut AnyObject) -> Result<(), String> {
     let app: *mut AnyObject = msg_send![class!(UIApplication), sharedApplication];

--- a/src/packages/image_picker/ios.rs
+++ b/src/packages/image_picker/ios.rs
@@ -1,7 +1,7 @@
 use super::{CameraDevice, ImagePickerOptions, ImageSource, PickedFile};
-use objc::declare::ClassDecl;
-use objc::runtime::{Class, Object, Sel, BOOL, YES};
-use objc::{class, msg_send, sel, sel_impl};
+use objc2::ffi::{BOOL, YES};
+use objc2::runtime::{AnyClass, AnyObject, ClassBuilder, Sel};
+use objc2::{class, msg_send, sel};
 use std::sync::{mpsc, Mutex, Once};
 
 #[link(name = "PhotosUI", kind = "framework")]
@@ -32,34 +32,34 @@ fn send_result(paths: Vec<String>) {
 // ── PHPicker delegate (iOS 14+ gallery picker) ─────────────────────────────
 
 static REGISTER_PHPICKER_DELEGATE: Once = Once::new();
-static mut PHPICKER_DELEGATE_CLASS: *const Class = std::ptr::null();
+static mut PHPICKER_DELEGATE_CLASS: *const AnyClass = std::ptr::null();
 
-fn phpicker_delegate_class() -> &'static Class {
+fn phpicker_delegate_class() -> &'static AnyClass {
     REGISTER_PHPICKER_DELEGATE.call_once(|| {
         let superclass = class!(NSObject);
-        let mut decl = ClassDecl::new("GpuiPHPickerDelegate", superclass).unwrap();
+        let mut decl = ClassBuilder::new("GpuiPHPickerDelegate", superclass).unwrap();
 
         unsafe {
             decl.add_method(
                 sel!(picker:didFinishPicking:),
-                phpicker_did_finish as extern "C" fn(&Object, Sel, *mut Object, *mut Object),
+                phpicker_did_finish as extern "C" fn(&AnyObject, Sel, *mut AnyObject, *mut AnyObject),
             );
         }
 
-        unsafe { PHPICKER_DELEGATE_CLASS = decl.register() };
+        unsafe { PHPICKER_DELEGATE_CLASS = decl.register() as *const AnyClass };
     });
     unsafe { &*PHPICKER_DELEGATE_CLASS }
 }
 
 extern "C" fn phpicker_did_finish(
-    _this: &Object,
+    _this: &AnyObject,
     _sel: Sel,
-    picker: *mut Object,
-    results: *mut Object,
+    picker: *mut AnyObject,
+    results: *mut AnyObject,
 ) {
     unsafe {
         // Dismiss the picker
-        let _: () = msg_send![picker, dismissViewControllerAnimated: YES completion: std::ptr::null::<Object>()];
+        let _: () = msg_send![picker, dismissViewControllerAnimated: YES completion: std::ptr::null::<AnyObject>()];
 
         let count: usize = msg_send![results, count];
         if count == 0 {
@@ -72,8 +72,8 @@ extern "C" fn phpicker_did_finish(
         let mut paths = Vec::with_capacity(count);
 
         for i in 0..count {
-            let result: *mut Object = msg_send![results, objectAtIndex: i];
-            let item_provider: *mut Object = msg_send![result, itemProvider];
+            let result: *mut AnyObject = msg_send![results, objectAtIndex: i];
+            let item_provider: *mut AnyObject = msg_send![result, itemProvider];
 
             // Check if it can load as UIImage
             let image_class = class!(UIImage);
@@ -95,17 +95,17 @@ extern "C" fn phpicker_did_finish(
 
                 // Use loadFileRepresentationForTypeIdentifier to get a temp file URL
                 let block = block::ConcreteBlock::new(
-                    move |url: *mut Object, _error: *mut Object| {
+                    move |url: *mut AnyObject, _error: *mut AnyObject| {
                         if url.is_null() {
                             let _ = item_tx.send(None);
                             return;
                         }
                         // Copy the file to our temp directory
-                        let file_mgr: *mut Object =
+                        let file_mgr: *mut AnyObject =
                             msg_send![class!(NSFileManager), defaultManager];
-                        let dest_url: *mut Object =
+                        let dest_url: *mut AnyObject =
                             msg_send![class!(NSURL), fileURLWithPath: nsstring(&path_copy)];
-                        let ok: BOOL = msg_send![file_mgr, copyItemAtURL: url toURL: dest_url error: std::ptr::null_mut::<*mut Object>()];
+                        let ok: BOOL = msg_send![file_mgr, copyItemAtURL: url toURL: dest_url error: std::ptr::null_mut::<*mut AnyObject>()];
                         if ok == YES {
                             let _ = item_tx.send(Some(path_copy.clone()));
                         } else {
@@ -115,7 +115,7 @@ extern "C" fn phpicker_did_finish(
                 );
                 let block = block.copy();
 
-                let _: *mut Object = msg_send![item_provider,
+                let _: *mut AnyObject = msg_send![item_provider,
                     loadFileRepresentationForTypeIdentifier: ns_uti
                     completionHandler: &*block
                 ];
@@ -133,44 +133,44 @@ extern "C" fn phpicker_did_finish(
 // ── UIImagePicker delegate (camera capture) ─────────────────────────────────
 
 static REGISTER_UIPICKER_DELEGATE: Once = Once::new();
-static mut UIPICKER_DELEGATE_CLASS: *const Class = std::ptr::null();
+static mut UIPICKER_DELEGATE_CLASS: *const AnyClass = std::ptr::null();
 
-fn uipicker_delegate_class() -> &'static Class {
+fn uipicker_delegate_class() -> &'static AnyClass {
     REGISTER_UIPICKER_DELEGATE.call_once(|| {
         let superclass = class!(NSObject);
-        let mut decl = ClassDecl::new("GpuiUIImagePickerDelegate", superclass).unwrap();
+        let mut decl = ClassBuilder::new("GpuiUIImagePickerDelegate", superclass).unwrap();
 
         unsafe {
             decl.add_method(
                 sel!(imagePickerController:didFinishPickingMediaWithInfo:),
-                uipicker_did_finish as extern "C" fn(&Object, Sel, *mut Object, *mut Object),
+                uipicker_did_finish as extern "C" fn(&AnyObject, Sel, *mut AnyObject, *mut AnyObject),
             );
             decl.add_method(
                 sel!(imagePickerControllerDidCancel:),
-                uipicker_did_cancel as extern "C" fn(&Object, Sel, *mut Object),
+                uipicker_did_cancel as extern "C" fn(&AnyObject, Sel, *mut AnyObject),
             );
         }
 
-        unsafe { UIPICKER_DELEGATE_CLASS = decl.register() };
+        unsafe { UIPICKER_DELEGATE_CLASS = decl.register() as *const AnyClass };
     });
     unsafe { &*UIPICKER_DELEGATE_CLASS }
 }
 
 extern "C" fn uipicker_did_finish(
-    _this: &Object,
+    _this: &AnyObject,
     _sel: Sel,
-    controller: *mut Object,
-    info: *mut Object,
+    controller: *mut AnyObject,
+    info: *mut AnyObject,
 ) {
     unsafe {
-        let _: () = msg_send![controller, dismissViewControllerAnimated: YES completion: std::ptr::null::<Object>()];
+        let _: () = msg_send![controller, dismissViewControllerAnimated: YES completion: std::ptr::null::<AnyObject>()];
 
         // Try to get the image URL first (for videos or saved photos)
         let media_url_key = nsstring("UIImagePickerControllerMediaURL");
-        let media_url: *mut Object = msg_send![info, objectForKey: media_url_key];
+        let media_url: *mut AnyObject = msg_send![info, objectForKey: media_url_key];
 
         if !media_url.is_null() {
-            let abs_string: *mut Object = msg_send![media_url, absoluteString];
+            let abs_string: *mut AnyObject = msg_send![media_url, absoluteString];
             let cstr: *const std::ffi::c_char = msg_send![abs_string, UTF8String];
             if !cstr.is_null() {
                 let path = std::ffi::CStr::from_ptr(cstr)
@@ -184,7 +184,7 @@ extern "C" fn uipicker_did_finish(
 
         // Fall back to getting the UIImage and saving it
         let image_key = nsstring("UIImagePickerControllerOriginalImage");
-        let image: *mut Object = msg_send![info, objectForKey: image_key];
+        let image: *mut AnyObject = msg_send![info, objectForKey: image_key];
 
         if !image.is_null() {
             // Convert to JPEG data
@@ -207,26 +207,26 @@ extern "C" fn uipicker_did_finish(
     }
 }
 
-extern "C" fn uipicker_did_cancel(_this: &Object, _sel: Sel, controller: *mut Object) {
+extern "C" fn uipicker_did_cancel(_this: &AnyObject, _sel: Sel, controller: *mut AnyObject) {
     unsafe {
-        let _: () = msg_send![controller, dismissViewControllerAnimated: YES completion: std::ptr::null::<Object>()];
+        let _: () = msg_send![controller, dismissViewControllerAnimated: YES completion: std::ptr::null::<AnyObject>()];
     }
     send_result(vec![]);
 }
 
 // UIImageJPEGRepresentation is a C function, not an ObjC method
 extern "C" {
-    fn UIImageJPEGRepresentation(image: *mut Object, quality: f64) -> *mut Object;
+    fn UIImageJPEGRepresentation(image: *mut AnyObject, quality: f64) -> *mut AnyObject;
 }
 
-unsafe fn uiimage_jpeg_representation(image: *mut Object, quality: f64) -> *mut Object {
+unsafe fn uiimage_jpeg_representation(image: *mut AnyObject, quality: f64) -> *mut AnyObject {
     UIImageJPEGRepresentation(image, quality)
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-unsafe fn nsstring(s: &str) -> *mut Object {
-    let ns: *mut Object = msg_send![class!(NSString), alloc];
+unsafe fn nsstring(s: &str) -> *mut AnyObject {
+    let ns: *mut AnyObject = msg_send![class!(NSString), alloc];
     msg_send![ns,
         initWithBytes: s.as_ptr() as *const std::ffi::c_void
         length: s.len()
@@ -234,20 +234,20 @@ unsafe fn nsstring(s: &str) -> *mut Object {
     ]
 }
 
-unsafe fn present_vc(vc: *mut Object) -> Result<(), String> {
-    let app: *mut Object = msg_send![class!(UIApplication), sharedApplication];
-    let key_window: *mut Object = msg_send![app, keyWindow];
+unsafe fn present_vc(vc: *mut AnyObject) -> Result<(), String> {
+    let app: *mut AnyObject = msg_send![class!(UIApplication), sharedApplication];
+    let key_window: *mut AnyObject = msg_send![app, keyWindow];
     if key_window.is_null() {
         return Err("No key window available".into());
     }
-    let root_vc: *mut Object = msg_send![key_window, rootViewController];
+    let root_vc: *mut AnyObject = msg_send![key_window, rootViewController];
     if root_vc.is_null() {
         return Err("No root view controller".into());
     }
     let _: () = msg_send![root_vc,
         presentViewController: vc
         animated: YES
-        completion: std::ptr::null::<Object>()
+        completion: std::ptr::null::<AnyObject>()
     ];
     Ok(())
 }
@@ -311,8 +311,8 @@ fn pick_image_from_gallery(
 
     unsafe {
         // PHPickerConfiguration
-        let config: *mut Object = msg_send![class!(PHPickerConfiguration), alloc];
-        let config: *mut Object = msg_send![config, init];
+        let config: *mut AnyObject = msg_send![class!(PHPickerConfiguration), alloc];
+        let config: *mut AnyObject = msg_send![config, init];
 
         if allow_multi {
             let _: () = msg_send![config, setSelectionLimit: 0i64]; // 0 = unlimited
@@ -321,20 +321,20 @@ fn pick_image_from_gallery(
         }
 
         // Filter to images only
-        let image_filter: *mut Object = msg_send![class!(PHPickerFilter), imagesFilter];
+        let image_filter: *mut AnyObject = msg_send![class!(PHPickerFilter), imagesFilter];
         let _: () = msg_send![config, setFilter: image_filter];
 
         // Create PHPickerViewController
-        let picker: *mut Object = msg_send![class!(PHPickerViewController), alloc];
-        let picker: *mut Object = msg_send![picker, initWithConfiguration: config];
+        let picker: *mut AnyObject = msg_send![class!(PHPickerViewController), alloc];
+        let picker: *mut AnyObject = msg_send![picker, initWithConfiguration: config];
         if picker.is_null() {
             return Err("Failed to create PHPickerViewController".into());
         }
 
         // Set delegate
         let delegate_cls = phpicker_delegate_class();
-        let delegate: *mut Object = msg_send![delegate_cls, alloc];
-        let delegate: *mut Object = msg_send![delegate, init];
+        let delegate: *mut AnyObject = msg_send![delegate_cls, alloc];
+        let delegate: *mut AnyObject = msg_send![delegate, init];
         let _: () = msg_send![picker, setDelegate: delegate];
 
         present_vc(picker)?;
@@ -351,23 +351,23 @@ fn pick_video_from_gallery() -> Result<Option<PickedFile>, String> {
 
     unsafe {
         // PHPickerConfiguration
-        let config: *mut Object = msg_send![class!(PHPickerConfiguration), alloc];
-        let config: *mut Object = msg_send![config, init];
+        let config: *mut AnyObject = msg_send![class!(PHPickerConfiguration), alloc];
+        let config: *mut AnyObject = msg_send![config, init];
         let _: () = msg_send![config, setSelectionLimit: 1i64];
 
         // Filter to videos only
-        let video_filter: *mut Object = msg_send![class!(PHPickerFilter), videosFilter];
+        let video_filter: *mut AnyObject = msg_send![class!(PHPickerFilter), videosFilter];
         let _: () = msg_send![config, setFilter: video_filter];
 
-        let picker: *mut Object = msg_send![class!(PHPickerViewController), alloc];
-        let picker: *mut Object = msg_send![picker, initWithConfiguration: config];
+        let picker: *mut AnyObject = msg_send![class!(PHPickerViewController), alloc];
+        let picker: *mut AnyObject = msg_send![picker, initWithConfiguration: config];
         if picker.is_null() {
             return Err("Failed to create PHPickerViewController".into());
         }
 
         let delegate_cls = phpicker_delegate_class();
-        let delegate: *mut Object = msg_send![delegate_cls, alloc];
-        let delegate: *mut Object = msg_send![delegate, init];
+        let delegate: *mut AnyObject = msg_send![delegate_cls, alloc];
+        let delegate: *mut AnyObject = msg_send![delegate, init];
         let _: () = msg_send![picker, setDelegate: delegate];
 
         present_vc(picker)?;
@@ -395,8 +395,8 @@ fn pick_from_camera(
             return Err("Camera is not available on this device".into());
         }
 
-        let picker: *mut Object = msg_send![class!(UIImagePickerController), alloc];
-        let picker: *mut Object = msg_send![picker, init];
+        let picker: *mut AnyObject = msg_send![class!(UIImagePickerController), alloc];
+        let picker: *mut AnyObject = msg_send![picker, init];
         if picker.is_null() {
             return Err("Failed to create UIImagePickerController".into());
         }
@@ -406,7 +406,7 @@ fn pick_from_camera(
         // Set media types
         if video {
             let video_type = nsstring("public.movie");
-            let types: *mut Object = msg_send![class!(NSArray), arrayWithObject: video_type];
+            let types: *mut AnyObject = msg_send![class!(NSArray), arrayWithObject: video_type];
             let _: () = msg_send![picker, setMediaTypes: types];
         }
 
@@ -419,8 +419,8 @@ fn pick_from_camera(
 
         // Set delegate
         let delegate_cls = uipicker_delegate_class();
-        let delegate: *mut Object = msg_send![delegate_cls, alloc];
-        let delegate: *mut Object = msg_send![delegate, init];
+        let delegate: *mut AnyObject = msg_send![delegate_cls, alloc];
+        let delegate: *mut AnyObject = msg_send![delegate, init];
         let _: () = msg_send![picker, setDelegate: delegate];
 
         present_vc(picker)?;

--- a/src/packages/image_picker/ios.rs
+++ b/src/packages/image_picker/ios.rs
@@ -37,12 +37,12 @@ static mut PHPICKER_DELEGATE_CLASS: *const AnyClass = std::ptr::null();
 fn phpicker_delegate_class() -> &'static AnyClass {
     REGISTER_PHPICKER_DELEGATE.call_once(|| {
         let superclass = class!(NSObject);
-        let mut decl = ClassBuilder::new("GpuiPHPickerDelegate", superclass).unwrap();
+        let mut decl = ClassBuilder::new(c"GpuiPHPickerDelegate", superclass).unwrap();
 
         unsafe {
             decl.add_method(
                 sel!(picker:didFinishPicking:),
-                phpicker_did_finish as extern "C" fn(&AnyObject, Sel, *mut AnyObject, *mut AnyObject),
+                phpicker_did_finish as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject, *mut AnyObject),
             );
         }
 
@@ -52,7 +52,7 @@ fn phpicker_delegate_class() -> &'static AnyClass {
 }
 
 extern "C" fn phpicker_did_finish(
-    _this: &AnyObject,
+    _this: *mut AnyObject,
     _sel: Sel,
     picker: *mut AnyObject,
     results: *mut AnyObject,
@@ -94,7 +94,7 @@ extern "C" fn phpicker_did_finish(
                 let path_copy = file_path_str.clone();
 
                 // Use loadFileRepresentationForTypeIdentifier to get a temp file URL
-                let block = block::ConcreteBlock::new(
+                let block = block2::RcBlock::new(
                     move |url: *mut AnyObject, _error: *mut AnyObject| {
                         if url.is_null() {
                             let _ = item_tx.send(None);
@@ -102,10 +102,10 @@ extern "C" fn phpicker_did_finish(
                         }
                         // Copy the file to our temp directory
                         let file_mgr: *mut AnyObject =
-                            msg_send![class!(NSFileManager), defaultManager];
+                            unsafe { msg_send![class!(NSFileManager), defaultManager] };
                         let dest_url: *mut AnyObject =
-                            msg_send![class!(NSURL), fileURLWithPath: nsstring(&path_copy)];
-                        let ok: BOOL = msg_send![file_mgr, copyItemAtURL: url toURL: dest_url error: std::ptr::null_mut::<*mut AnyObject>()];
+                            unsafe { msg_send![class!(NSURL), fileURLWithPath: nsstring(&path_copy)] };
+                        let ok: BOOL = unsafe { msg_send![file_mgr, copyItemAtURL: url toURL: dest_url error: std::ptr::null_mut::<*mut AnyObject>()] };
                         if ok == YES {
                             let _ = item_tx.send(Some(path_copy.clone()));
                         } else {
@@ -113,7 +113,6 @@ extern "C" fn phpicker_did_finish(
                         }
                     },
                 );
-                let block = block.copy();
 
                 let _: *mut AnyObject = msg_send![item_provider,
                     loadFileRepresentationForTypeIdentifier: ns_uti
@@ -138,16 +137,16 @@ static mut UIPICKER_DELEGATE_CLASS: *const AnyClass = std::ptr::null();
 fn uipicker_delegate_class() -> &'static AnyClass {
     REGISTER_UIPICKER_DELEGATE.call_once(|| {
         let superclass = class!(NSObject);
-        let mut decl = ClassBuilder::new("GpuiUIImagePickerDelegate", superclass).unwrap();
+        let mut decl = ClassBuilder::new(c"GpuiUIImagePickerDelegate", superclass).unwrap();
 
         unsafe {
             decl.add_method(
                 sel!(imagePickerController:didFinishPickingMediaWithInfo:),
-                uipicker_did_finish as extern "C" fn(&AnyObject, Sel, *mut AnyObject, *mut AnyObject),
+                uipicker_did_finish as unsafe extern "C" fn(*mut AnyObject, Sel, *mut AnyObject, *mut AnyObject),
             );
             decl.add_method(
                 sel!(imagePickerControllerDidCancel:),
-                uipicker_did_cancel as extern "C" fn(&AnyObject, Sel, *mut AnyObject),
+                uipicker_did_cancel as unsafe extern "C" fn(*mut AnyObject, Sel, *mut AnyObject),
             );
         }
 
@@ -156,61 +155,57 @@ fn uipicker_delegate_class() -> &'static AnyClass {
     unsafe { &*UIPICKER_DELEGATE_CLASS }
 }
 
-extern "C" fn uipicker_did_finish(
-    _this: &AnyObject,
+unsafe extern "C" fn uipicker_did_finish(
+    _this: *mut AnyObject,
     _sel: Sel,
     controller: *mut AnyObject,
     info: *mut AnyObject,
 ) {
-    unsafe {
-        let _: () = msg_send![controller, dismissViewControllerAnimated: YES completion: std::ptr::null::<AnyObject>()];
+    let _: () = msg_send![controller, dismissViewControllerAnimated: YES completion: std::ptr::null::<AnyObject>()];
 
-        // Try to get the image URL first (for videos or saved photos)
-        let media_url_key = nsstring("UIImagePickerControllerMediaURL");
-        let media_url: *mut AnyObject = msg_send![info, objectForKey: media_url_key];
+    // Try to get the image URL first (for videos or saved photos)
+    let media_url_key = nsstring("UIImagePickerControllerMediaURL");
+    let media_url: *mut AnyObject = msg_send![info, objectForKey: media_url_key];
 
-        if !media_url.is_null() {
-            let abs_string: *mut AnyObject = msg_send![media_url, absoluteString];
-            let cstr: *const std::ffi::c_char = msg_send![abs_string, UTF8String];
-            if !cstr.is_null() {
-                let path = std::ffi::CStr::from_ptr(cstr)
-                    .to_string_lossy()
-                    .into_owned();
-                let path = path.strip_prefix("file://").unwrap_or(&path).to_string();
-                send_result(vec![path]);
+    if !media_url.is_null() {
+        let abs_string: *mut AnyObject = msg_send![media_url, absoluteString];
+        let cstr: *const std::ffi::c_char = msg_send![abs_string, UTF8String];
+        if !cstr.is_null() {
+            let path = std::ffi::CStr::from_ptr(cstr)
+                .to_string_lossy()
+                .into_owned();
+            let path = path.strip_prefix("file://").unwrap_or(&path).to_string();
+            send_result(vec![path]);
+            return;
+        }
+    }
+
+    // Fall back to getting the UIImage and saving it
+    let image_key = nsstring("UIImagePickerControllerOriginalImage");
+    let image: *mut AnyObject = msg_send![info, objectForKey: image_key];
+
+    if !image.is_null() {
+        // Convert to JPEG data
+        // Use UIImageJPEGRepresentation C function
+        let jpeg_data = uiimage_jpeg_representation(image, 0.9);
+        if !jpeg_data.is_null() {
+            let uuid_str = uuid::Uuid::new_v4().to_string();
+            let file_name = format!("captured_{}.jpg", uuid_str);
+            let file_path = std::env::temp_dir().join(file_name);
+            let ns_path = nsstring(&file_path.to_string_lossy());
+            let wrote: BOOL = msg_send![jpeg_data, writeToFile: ns_path atomically: YES];
+            if wrote == YES {
+                send_result(vec![file_path.to_string_lossy().into_owned()]);
                 return;
             }
         }
-
-        // Fall back to getting the UIImage and saving it
-        let image_key = nsstring("UIImagePickerControllerOriginalImage");
-        let image: *mut AnyObject = msg_send![info, objectForKey: image_key];
-
-        if !image.is_null() {
-            // Convert to JPEG data
-            // Use UIImageJPEGRepresentation C function
-            let jpeg_data = uiimage_jpeg_representation(image, 0.9);
-            if !jpeg_data.is_null() {
-                let uuid_str = uuid::Uuid::new_v4().to_string();
-                let file_name = format!("captured_{}.jpg", uuid_str);
-                let file_path = std::env::temp_dir().join(file_name);
-                let ns_path = nsstring(&file_path.to_string_lossy());
-                let wrote: BOOL = msg_send![jpeg_data, writeToFile: ns_path atomically: YES];
-                if wrote == YES {
-                    send_result(vec![file_path.to_string_lossy().into_owned()]);
-                    return;
-                }
-            }
-        }
-
-        send_result(vec![]);
     }
+
+    send_result(vec![]);
 }
 
-extern "C" fn uipicker_did_cancel(_this: &AnyObject, _sel: Sel, controller: *mut AnyObject) {
-    unsafe {
-        let _: () = msg_send![controller, dismissViewControllerAnimated: YES completion: std::ptr::null::<AnyObject>()];
-    }
+unsafe extern "C" fn uipicker_did_cancel(_this: *mut AnyObject, _sel: Sel, controller: *mut AnyObject) {
+    let _: () = msg_send![controller, dismissViewControllerAnimated: YES completion: std::ptr::null::<AnyObject>()];
     send_result(vec![]);
 }
 

--- a/src/packages/image_picker/ios.rs
+++ b/src/packages/image_picker/ios.rs
@@ -42,7 +42,8 @@ fn phpicker_delegate_class() -> &'static AnyClass {
         unsafe {
             decl.add_method(
                 sel!(picker:didFinishPicking:),
-                phpicker_did_finish as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject, *mut AnyObject),
+                phpicker_did_finish
+                    as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject, *mut AnyObject),
             );
         }
 
@@ -103,9 +104,12 @@ extern "C" fn phpicker_did_finish(
                         // Copy the file to our temp directory
                         let file_mgr: *mut AnyObject =
                             unsafe { msg_send![class!(NSFileManager), defaultManager] };
-                        let dest_url: *mut AnyObject =
-                            unsafe { msg_send![class!(NSURL), fileURLWithPath: nsstring(&path_copy)] };
-                        let ok: BOOL = unsafe { msg_send![file_mgr, copyItemAtURL: url toURL: dest_url error: std::ptr::null_mut::<*mut AnyObject>()] };
+                        let dest_url: *mut AnyObject = unsafe {
+                            msg_send![class!(NSURL), fileURLWithPath: nsstring(&path_copy)]
+                        };
+                        let ok: BOOL = unsafe {
+                            msg_send![file_mgr, copyItemAtURL: url toURL: dest_url error: std::ptr::null_mut::<*mut AnyObject>()]
+                        };
                         if ok == YES {
                             let _ = item_tx.send(Some(path_copy.clone()));
                         } else {
@@ -142,7 +146,8 @@ fn uipicker_delegate_class() -> &'static AnyClass {
         unsafe {
             decl.add_method(
                 sel!(imagePickerController:didFinishPickingMediaWithInfo:),
-                uipicker_did_finish as unsafe extern "C" fn(*mut AnyObject, Sel, *mut AnyObject, *mut AnyObject),
+                uipicker_did_finish
+                    as unsafe extern "C" fn(*mut AnyObject, Sel, *mut AnyObject, *mut AnyObject),
             );
             decl.add_method(
                 sel!(imagePickerControllerDidCancel:),
@@ -204,7 +209,11 @@ unsafe extern "C" fn uipicker_did_finish(
     send_result(vec![]);
 }
 
-unsafe extern "C" fn uipicker_did_cancel(_this: *mut AnyObject, _sel: Sel, controller: *mut AnyObject) {
+unsafe extern "C" fn uipicker_did_cancel(
+    _this: *mut AnyObject,
+    _sel: Sel,
+    controller: *mut AnyObject,
+) {
     let _: () = msg_send![controller, dismissViewControllerAnimated: YES completion: std::ptr::null::<AnyObject>()];
     send_result(vec![]);
 }

--- a/src/packages/in_app_review/ios.rs
+++ b/src/packages/in_app_review/ios.rs
@@ -1,5 +1,5 @@
-use objc::runtime::Object;
-use objc::{class, msg_send, sel, sel_impl};
+use objc2::runtime::AnyObject;
+use objc2::{class, msg_send, sel};
 use std::ffi::CString;
 
 #[link(name = "StoreKit", kind = "framework")]
@@ -22,16 +22,16 @@ pub fn open_store_listing(app_id: &str) -> Result<(), String> {
     unsafe {
         let url_str = format!("https://apps.apple.com/app/id{}", app_id);
         let c_url_str = CString::new(url_str).map_err(|e| e.to_string())?;
-        let ns_url_str: *mut Object = msg_send![class!(NSString), alloc];
-        let ns_url_str: *mut Object = msg_send![ns_url_str, initWithUTF8String: c_url_str.as_ptr()];
+        let ns_url_str: *mut AnyObject = msg_send![class!(NSString), alloc];
+        let ns_url_str: *mut AnyObject = msg_send![ns_url_str, initWithUTF8String: c_url_str.as_ptr()];
         if ns_url_str.is_null() {
             return Err("Failed to create NSString for URL".into());
         }
-        let url: *mut Object = msg_send![class!(NSURL), URLWithString: ns_url_str];
+        let url: *mut AnyObject = msg_send![class!(NSURL), URLWithString: ns_url_str];
         if url.is_null() {
             return Err("Failed to create NSURL".into());
         }
-        let app: *mut Object = msg_send![class!(UIApplication), sharedApplication];
+        let app: *mut AnyObject = msg_send![class!(UIApplication), sharedApplication];
         if app.is_null() {
             return Err("Failed to get UIApplication".into());
         }

--- a/src/packages/in_app_review/ios.rs
+++ b/src/packages/in_app_review/ios.rs
@@ -23,7 +23,8 @@ pub fn open_store_listing(app_id: &str) -> Result<(), String> {
         let url_str = format!("https://apps.apple.com/app/id{}", app_id);
         let c_url_str = CString::new(url_str).map_err(|e| e.to_string())?;
         let ns_url_str: *mut AnyObject = msg_send![class!(NSString), alloc];
-        let ns_url_str: *mut AnyObject = msg_send![ns_url_str, initWithUTF8String: c_url_str.as_ptr()];
+        let ns_url_str: *mut AnyObject =
+            msg_send![ns_url_str, initWithUTF8String: c_url_str.as_ptr()];
         if ns_url_str.is_null() {
             return Err("Failed to create NSString for URL".into());
         }

--- a/src/packages/local_auth/ios.rs
+++ b/src/packages/local_auth/ios.rs
@@ -1,6 +1,6 @@
 use super::{AuthResult, BiometricType};
-use objc::runtime::Object;
-use objc::{class, msg_send, sel, sel_impl};
+use objc2::runtime::AnyObject;
+use objc2::{class, msg_send, sel};
 use std::ffi::c_void;
 
 /// LAPolicy constants.
@@ -20,9 +20,9 @@ const LA_ERROR_BIOMETRY_NOT_AVAILABLE: i64 = -6;
 const LA_ERROR_BIOMETRY_NOT_ENROLLED: i64 = -7;
 const LA_ERROR_BIOMETRY_LOCKOUT: i64 = -8;
 
-unsafe fn create_la_context() -> *mut Object {
-    let context: *mut Object = msg_send![class!(LAContext), alloc];
-    let context: *mut Object = msg_send![context, init];
+unsafe fn create_la_context() -> *mut AnyObject {
+    let context: *mut AnyObject = msg_send![class!(LAContext), alloc];
+    let context: *mut AnyObject = msg_send![context, init];
     context
 }
 
@@ -37,7 +37,7 @@ pub fn is_device_supported() -> Result<bool, String> {
         let can_evaluate: bool = msg_send![
             context,
             canEvaluatePolicy: LA_POLICY_DEVICE_OWNER_AUTHENTICATION_WITH_BIOMETRICS
-            error: std::ptr::null_mut::<*mut Object>()
+            error: std::ptr::null_mut::<*mut AnyObject>()
         ];
 
         // Even if canEvaluatePolicy returns false (e.g. not enrolled), the device
@@ -59,7 +59,7 @@ pub fn can_authenticate() -> Result<bool, String> {
         let can_evaluate: bool = msg_send![
             context,
             canEvaluatePolicy: LA_POLICY_DEVICE_OWNER_AUTHENTICATION_WITH_BIOMETRICS
-            error: std::ptr::null_mut::<*mut Object>()
+            error: std::ptr::null_mut::<*mut AnyObject>()
         ];
 
         let _: () = msg_send![context, release];
@@ -78,7 +78,7 @@ pub fn get_available_biometrics() -> Result<Vec<BiometricType>, String> {
         let _can: bool = msg_send![
             context,
             canEvaluatePolicy: LA_POLICY_DEVICE_OWNER_AUTHENTICATION_WITH_BIOMETRICS
-            error: std::ptr::null_mut::<*mut Object>()
+            error: std::ptr::null_mut::<*mut AnyObject>()
         ];
 
         let biometry_type: i64 = msg_send![context, biometryType];
@@ -106,7 +106,7 @@ pub fn authenticate(reason: &str) -> Result<AuthResult, String> {
         let can_evaluate: bool = msg_send![
             context,
             canEvaluatePolicy: LA_POLICY_DEVICE_OWNER_AUTHENTICATION_WITH_BIOMETRICS
-            error: std::ptr::null_mut::<*mut Object>()
+            error: std::ptr::null_mut::<*mut AnyObject>()
         ];
 
         if !can_evaluate {
@@ -120,9 +120,9 @@ pub fn authenticate(reason: &str) -> Result<AuthResult, String> {
         }
 
         // Create NSString for reason
-        let reason_nsstring: *mut Object = msg_send![class!(NSString), alloc];
+        let reason_nsstring: *mut AnyObject = msg_send![class!(NSString), alloc];
         let reason_bytes = reason.as_bytes();
-        let reason_nsstring: *mut Object = msg_send![
+        let reason_nsstring: *mut AnyObject = msg_send![
             reason_nsstring,
             initWithBytes: reason_bytes.as_ptr() as *const c_void
             length: reason_bytes.len()
@@ -138,7 +138,7 @@ pub fn authenticate(reason: &str) -> Result<AuthResult, String> {
 
         // Create the reply block.
         // The block signature is: void (^)(BOOL success, NSError *error)
-        let block = block::ConcreteBlock::new(move |success: bool, error: *mut Object| {
+        let block = block::ConcreteBlock::new(move |success: bool, error: *mut AnyObject| {
             let auth_result = if success {
                 AuthResult::Success
             } else if error.is_null() {
@@ -196,8 +196,8 @@ pub fn authenticate(reason: &str) -> Result<AuthResult, String> {
 const DISPATCH_TIME_FOREVER: u64 = !0;
 
 extern "C" {
-    fn dispatch_semaphore_create(value: i64) -> *mut Object;
-    fn dispatch_semaphore_signal(dsema: *mut Object) -> i64;
-    fn dispatch_semaphore_wait(dsema: *mut Object, timeout: u64) -> i64;
+    fn dispatch_semaphore_create(value: i64) -> *mut AnyObject;
+    fn dispatch_semaphore_signal(dsema: *mut AnyObject) -> i64;
+    fn dispatch_semaphore_wait(dsema: *mut AnyObject, timeout: u64) -> i64;
     fn dispatch_release(object: *mut c_void);
 }

--- a/src/packages/local_auth/ios.rs
+++ b/src/packages/local_auth/ios.rs
@@ -1,5 +1,5 @@
 use super::{AuthResult, BiometricType};
-use objc2::runtime::AnyObject;
+use objc2::runtime::{AnyObject, Bool};
 use objc2::{class, msg_send, sel};
 use std::ffi::c_void;
 
@@ -138,13 +138,13 @@ pub fn authenticate(reason: &str) -> Result<AuthResult, String> {
 
         // Create the reply block.
         // The block signature is: void (^)(BOOL success, NSError *error)
-        let block = block::ConcreteBlock::new(move |success: bool, error: *mut AnyObject| {
-            let auth_result = if success {
+        let block = block2::RcBlock::new(move |success: Bool, error: *mut AnyObject| {
+            let auth_result = if success.as_bool() {
                 AuthResult::Success
             } else if error.is_null() {
                 AuthResult::Failed
             } else {
-                let error_code: i64 = msg_send![error, code];
+                let error_code: i64 = unsafe { msg_send![error, code] };
                 match error_code {
                     LA_ERROR_AUTHENTICATION_FAILED => AuthResult::Failed,
                     LA_ERROR_USER_CANCEL => AuthResult::ErrorUserCancelled,
@@ -158,13 +158,12 @@ pub fn authenticate(reason: &str) -> Result<AuthResult, String> {
             };
 
             // Store the result
-            if let Ok(mut guard) = (*result_holder).lock() {
+            if let Ok(mut guard) = unsafe { (*result_holder).lock() } {
                 *guard = auth_result;
             }
 
-            dispatch_semaphore_signal(semaphore);
+            unsafe { dispatch_semaphore_signal(semaphore) };
         });
-        let block = block.copy();
 
         // Call evaluatePolicy:localizedReason:reply:
         let _: () = msg_send![

--- a/src/packages/location/ios.rs
+++ b/src/packages/location/ios.rs
@@ -1,4 +1,5 @@
 use super::{LocationAccuracy, LocationSettings, Position};
+use objc2::encode::{Encode, Encoding, RefEncode};
 use objc2::runtime::AnyObject;
 use objc2::{class, msg_send, sel};
 use std::sync::OnceLock;
@@ -9,6 +10,17 @@ use std::sync::OnceLock;
 struct CLLocationCoordinate2D {
     latitude: f64,
     longitude: f64,
+}
+
+unsafe impl Encode for CLLocationCoordinate2D {
+    const ENCODING: Encoding = Encoding::Struct(
+        "CLLocationCoordinate2D",
+        &[Encoding::Double, Encoding::Double],
+    );
+}
+
+unsafe impl RefEncode for CLLocationCoordinate2D {
+    const ENCODING_REF: Encoding = Encoding::Pointer(&Self::ENCODING);
 }
 
 pub fn is_location_service_enabled() -> Result<bool, String> {

--- a/src/packages/location/ios.rs
+++ b/src/packages/location/ios.rs
@@ -1,6 +1,6 @@
 use super::{LocationAccuracy, LocationSettings, Position};
-use objc::runtime::Object;
-use objc::{class, msg_send, sel, sel_impl};
+use objc2::runtime::AnyObject;
+use objc2::{class, msg_send, sel};
 use std::sync::OnceLock;
 
 /// CLLocation coordinate struct matching CoreLocation's CLLocationCoordinate2D.
@@ -39,7 +39,7 @@ pub fn get_current_position(settings: &LocationSettings) -> Result<Position, Str
 
         // Give CLLocationManager time to acquire a fix.
         // In a production app this would use a delegate callback; here we poll.
-        let mut location: *mut Object = std::ptr::null_mut();
+        let mut location: *mut AnyObject = std::ptr::null_mut();
         for _ in 0..60 {
             std::thread::sleep(std::time::Duration::from_millis(500));
             location = msg_send![manager, location];
@@ -63,7 +63,7 @@ pub fn get_last_known_position() -> Result<Option<Position>, String> {
             return Err("Failed to create CLLocationManager".into());
         }
 
-        let location: *mut Object = msg_send![manager, location];
+        let location: *mut AnyObject = msg_send![manager, location];
         if location.is_null() {
             return Ok(None);
         }
@@ -72,7 +72,7 @@ pub fn get_last_known_position() -> Result<Option<Position>, String> {
     }
 }
 
-unsafe fn parse_cl_location(location: *mut Object) -> Position {
+unsafe fn parse_cl_location(location: *mut AnyObject) -> Position {
     let coord: CLLocationCoordinate2D = msg_send![location, coordinate];
     let altitude: f64 = msg_send![location, altitude];
     let horizontal_accuracy: f64 = msg_send![location, horizontalAccuracy];
@@ -82,7 +82,7 @@ unsafe fn parse_cl_location(location: *mut Object) -> Position {
     let course_accuracy: f64 = msg_send![location, courseAccuracy];
 
     // Get timestamp as unix millis from NSDate
-    let timestamp_obj: *mut Object = msg_send![location, timestamp];
+    let timestamp_obj: *mut AnyObject = msg_send![location, timestamp];
     let time_interval: f64 = msg_send![timestamp_obj, timeIntervalSince1970];
     let timestamp_millis = (time_interval * 1000.0) as u64;
 
@@ -128,13 +128,13 @@ fn cl_accuracy(accuracy: LocationAccuracy) -> f64 {
 /// Get or create a shared CLLocationManager instance.
 ///
 /// CLLocationManager is typically used as a singleton per app.
-unsafe fn get_location_manager() -> *mut Object {
+unsafe fn get_location_manager() -> *mut AnyObject {
     static MANAGER: OnceLock<usize> = OnceLock::new();
 
     let ptr = MANAGER.get_or_init(|| {
-        let manager: *mut Object = msg_send![class!(CLLocationManager), alloc];
-        let manager: *mut Object = msg_send![manager, init];
+        let manager: *mut AnyObject = msg_send![class!(CLLocationManager), alloc];
+        let manager: *mut AnyObject = msg_send![manager, init];
         manager as usize
     });
-    *ptr as *mut Object
+    *ptr as *mut AnyObject
 }

--- a/src/packages/maps_launcher/ios.rs
+++ b/src/packages/maps_launcher/ios.rs
@@ -1,5 +1,5 @@
-use objc::runtime::Object;
-use objc::{class, msg_send, sel, sel_impl};
+use objc2::runtime::AnyObject;
+use objc2::{class, msg_send, sel};
 
 pub fn open_coordinates(
     latitude: f64,
@@ -51,7 +51,7 @@ pub fn is_available() -> Result<bool, String> {
 fn open_url(url_string: &str) -> Result<bool, String> {
     unsafe {
         let nsurl = nsurl_from_str(url_string)?;
-        let app: *mut Object = msg_send![class!(UIApplication), sharedApplication];
+        let app: *mut AnyObject = msg_send![class!(UIApplication), sharedApplication];
         if app.is_null() {
             return Err("Failed to get UIApplication.sharedApplication".into());
         }
@@ -65,15 +65,15 @@ fn open_url(url_string: &str) -> Result<bool, String> {
     }
 }
 
-unsafe fn nsurl_from_str(url: &str) -> Result<*mut Object, String> {
-    let ns_string: *mut Object = msg_send![class!(NSString), alloc];
-    let ns_string: *mut Object = msg_send![ns_string, initWithBytes: url.as_ptr()
+unsafe fn nsurl_from_str(url: &str) -> Result<*mut AnyObject, String> {
+    let ns_string: *mut AnyObject = msg_send![class!(NSString), alloc];
+    let ns_string: *mut AnyObject = msg_send![ns_string, initWithBytes: url.as_ptr()
                                                        length: url.len()
                                                        encoding: 4u64];
     if ns_string.is_null() {
         return Err("Failed to create NSString from URL".into());
     }
-    let nsurl: *mut Object = msg_send![class!(NSURL), URLWithString: ns_string];
+    let nsurl: *mut AnyObject = msg_send![class!(NSURL), URLWithString: ns_string];
     if nsurl.is_null() {
         return Err(format!("Failed to parse URL: {url}"));
     }

--- a/src/packages/microphone/ios.rs
+++ b/src/packages/microphone/ios.rs
@@ -1,13 +1,13 @@
 use super::{AudioFormat, Recording, RecordingConfig};
-use objc::runtime::Object;
-use objc::{class, msg_send, sel, sel_impl};
+use objc2::runtime::AnyObject;
+use objc2::{class, msg_send, sel};
 use std::sync::Mutex;
 
 #[link(name = "AVFoundation", kind = "framework")]
 extern "C" {}
 
 struct RecorderState {
-    recorder: *mut Object, // AVAudioRecorder
+    recorder: *mut AnyObject, // AVAudioRecorder
     path: String,
     start_time: std::time::Instant,
 }
@@ -41,13 +41,13 @@ pub fn start_recording(config: &RecordingConfig) -> Result<String, String> {
 
         // Create NSURL
         let ns_path = nsstring(&path_str);
-        let file_url: *mut Object = msg_send![class!(NSURL), fileURLWithPath: ns_path];
+        let file_url: *mut AnyObject = msg_send![class!(NSURL), fileURLWithPath: ns_path];
         if file_url.is_null() {
             return Err("Failed to create file URL".into());
         }
 
         // Build settings dictionary
-        let keys: [*mut Object; 4] = [
+        let keys: [*mut AnyObject; 4] = [
             nsstring("AVFormatIDKey"),
             nsstring("AVSampleRateKey"),
             nsstring("AVNumberOfChannelsKey"),
@@ -60,31 +60,31 @@ pub fn start_recording(config: &RecordingConfig) -> Result<String, String> {
             AudioFormat::Amr => 1935764850, // kAudioFormatAMR (not well supported on iOS)
         };
 
-        let values: [*mut Object; 4] = [
+        let values: [*mut AnyObject; 4] = [
             number_with_int(format_id),
             number_with_float(config.sample_rate as f64),
             number_with_int(config.channels as i32),
             number_with_int(config.bit_rate as i32),
         ];
 
-        let settings: *mut Object = msg_send![class!(NSDictionary),
+        let settings: *mut AnyObject = msg_send![class!(NSDictionary),
             dictionaryWithObjects: values.as_ptr()
             forKeys: keys.as_ptr()
             count: 4usize
         ];
 
         // Create AVAudioRecorder
-        let mut error: *mut Object = std::ptr::null_mut();
-        let recorder: *mut Object = msg_send![class!(AVAudioRecorder), alloc];
-        let recorder: *mut Object = msg_send![recorder,
+        let mut error: *mut AnyObject = std::ptr::null_mut();
+        let recorder: *mut AnyObject = msg_send![class!(AVAudioRecorder), alloc];
+        let recorder: *mut AnyObject = msg_send![recorder,
             initWithURL: file_url
             settings: settings
-            error: &mut error as *mut *mut Object
+            error: &mut error as *mut *mut AnyObject
         ];
 
         if recorder.is_null() || !error.is_null() {
             let err_msg = if !error.is_null() {
-                let desc: *mut Object = msg_send![error, localizedDescription];
+                let desc: *mut AnyObject = msg_send![error, localizedDescription];
                 objc_string_to_rust(desc)
             } else {
                 "Failed to create recorder".to_string()
@@ -96,16 +96,16 @@ pub fn start_recording(config: &RecordingConfig) -> Result<String, String> {
         let _: () = msg_send![recorder, setMeteringEnabled: true];
 
         // Activate audio session
-        let session: *mut Object = msg_send![class!(AVAudioSession), sharedInstance];
+        let session: *mut AnyObject = msg_send![class!(AVAudioSession), sharedInstance];
         let record_category = nsstring("AVAudioSessionCategoryRecord");
-        let mut session_error: *mut Object = std::ptr::null_mut();
+        let mut session_error: *mut AnyObject = std::ptr::null_mut();
         let _: () = msg_send![session,
             setCategory: record_category
-            error: &mut session_error as *mut *mut Object
+            error: &mut session_error as *mut *mut AnyObject
         ];
         let _: () = msg_send![session,
             setActive: true
-            error: &mut session_error as *mut *mut Object
+            error: &mut session_error as *mut *mut AnyObject
         ];
 
         // Start recording
@@ -133,11 +133,11 @@ pub fn stop_recording() -> Result<Recording, String> {
         let duration_ms = state.start_time.elapsed().as_millis() as u64;
 
         // Deactivate audio session
-        let session: *mut Object = msg_send![class!(AVAudioSession), sharedInstance];
-        let mut error: *mut Object = std::ptr::null_mut();
+        let session: *mut AnyObject = msg_send![class!(AVAudioSession), sharedInstance];
+        let mut error: *mut AnyObject = std::ptr::null_mut();
         let _: () = msg_send![session,
             setActive: false
-            error: &mut error as *mut *mut Object
+            error: &mut error as *mut *mut AnyObject
         ];
 
         Ok(Recording {
@@ -196,8 +196,8 @@ pub fn get_amplitude() -> Result<f64, String> {
 
 // Helpers
 
-unsafe fn nsstring(s: &str) -> *mut Object {
-    let ns: *mut Object = msg_send![class!(NSString), alloc];
+unsafe fn nsstring(s: &str) -> *mut AnyObject {
+    let ns: *mut AnyObject = msg_send![class!(NSString), alloc];
     msg_send![ns,
         initWithBytes: s.as_ptr() as *const std::ffi::c_void
         length: s.len()
@@ -205,15 +205,15 @@ unsafe fn nsstring(s: &str) -> *mut Object {
     ]
 }
 
-unsafe fn number_with_int(val: i32) -> *mut Object {
+unsafe fn number_with_int(val: i32) -> *mut AnyObject {
     msg_send![class!(NSNumber), numberWithInt: val]
 }
 
-unsafe fn number_with_float(val: f64) -> *mut Object {
+unsafe fn number_with_float(val: f64) -> *mut AnyObject {
     msg_send![class!(NSNumber), numberWithDouble: val]
 }
 
-unsafe fn objc_string_to_rust(ns: *mut Object) -> String {
+unsafe fn objc_string_to_rust(ns: *mut AnyObject) -> String {
     if ns.is_null() {
         return String::new();
     }

--- a/src/packages/microphone/ios.rs
+++ b/src/packages/microphone/ios.rs
@@ -196,14 +196,7 @@ pub fn get_amplitude() -> Result<f64, String> {
 
 // Helpers
 
-unsafe fn nsstring(s: &str) -> *mut AnyObject {
-    let ns: *mut AnyObject = msg_send![class!(NSString), alloc];
-    msg_send![ns,
-        initWithBytes: s.as_ptr() as *const std::ffi::c_void
-        length: s.len()
-        encoding: 4u64 // NSUTF8StringEncoding
-    ]
-}
+use crate::ios::util::nsstring;
 
 unsafe fn number_with_int(val: i32) -> *mut AnyObject {
     msg_send![class!(NSNumber), numberWithInt: val]

--- a/src/packages/notifications/ios.rs
+++ b/src/packages/notifications/ios.rs
@@ -1,9 +1,9 @@
 use super::Notification;
-use objc::runtime::Object;
-use objc::{class, msg_send, sel, sel_impl};
+use objc2::runtime::AnyObject;
+use objc2::{class, msg_send, sel};
 
 /// Get the shared UNUserNotificationCenter instance.
-unsafe fn notification_center() -> *mut Object {
+unsafe fn notification_center() -> *mut AnyObject {
     msg_send![class!(UNUserNotificationCenter), currentNotificationCenter]
 }
 
@@ -21,7 +21,7 @@ pub fn initialize() -> Result<(), String> {
         // We pass a nil completion handler for simplicity — authorization is
         // granted asynchronously and the first show() call will work once the
         // user has responded to the system prompt.
-        let null_block: *mut Object = std::ptr::null_mut();
+        let null_block: *mut AnyObject = std::ptr::null_mut();
         let _: () = msg_send![
             center,
             requestAuthorizationWithOptions: options
@@ -40,8 +40,8 @@ pub fn show(notification: &Notification) -> Result<(), String> {
         }
 
         // Create UNMutableNotificationContent
-        let content: *mut Object = msg_send![class!(UNMutableNotificationContent), alloc];
-        let content: *mut Object = msg_send![content, init];
+        let content: *mut AnyObject = msg_send![class!(UNMutableNotificationContent), alloc];
+        let content: *mut AnyObject = msg_send![content, init];
         if content.is_null() {
             return Err("Failed to create UNMutableNotificationContent".into());
         }
@@ -55,14 +55,14 @@ pub fn show(notification: &Notification) -> Result<(), String> {
         let _: () = msg_send![content, setBody: body];
 
         // Set sound to default
-        let default_sound: *mut Object = msg_send![class!(UNNotificationSound), defaultSound];
+        let default_sound: *mut AnyObject = msg_send![class!(UNNotificationSound), defaultSound];
         let _: () = msg_send![content, setSound: default_sound];
 
         // Set userInfo with payload if present
         if let Some(ref payload) = notification.payload {
             let payload_str = nsstring(payload);
             let key = nsstring("payload");
-            let user_info: *mut Object = msg_send![
+            let user_info: *mut AnyObject = msg_send![
                 class!(NSDictionary),
                 dictionaryWithObject: payload_str
                 forKey: key
@@ -72,8 +72,8 @@ pub fn show(notification: &Notification) -> Result<(), String> {
 
         // Create a UNNotificationRequest with the notification ID as identifier
         let identifier = nsstring(&notification.id.to_string());
-        let null_trigger: *mut Object = std::ptr::null_mut();
-        let request: *mut Object = msg_send![
+        let null_trigger: *mut AnyObject = std::ptr::null_mut();
+        let request: *mut AnyObject = msg_send![
             class!(UNNotificationRequest),
             requestWithIdentifier: identifier
             content: content
@@ -85,7 +85,7 @@ pub fn show(notification: &Notification) -> Result<(), String> {
         }
 
         // Add the request to the notification center (nil completion handler)
-        let null_block: *mut Object = std::ptr::null_mut();
+        let null_block: *mut AnyObject = std::ptr::null_mut();
         let _: () = msg_send![
             center,
             addNotificationRequest: request
@@ -104,7 +104,7 @@ pub fn cancel(id: i32) -> Result<(), String> {
         }
 
         let identifier = nsstring(&id.to_string());
-        let array: *mut Object = msg_send![
+        let array: *mut AnyObject = msg_send![
             class!(NSArray),
             arrayWithObject: identifier
         ];
@@ -138,11 +138,11 @@ pub fn cancel_all() -> Result<(), String> {
 }
 
 /// Create an NSString from a Rust string slice.
-unsafe fn nsstring(s: &str) -> *mut Object {
+unsafe fn nsstring(s: &str) -> *mut AnyObject {
     let cls = class!(NSString);
     let bytes = s.as_ptr();
     let len = s.len();
-    let obj: *mut Object = msg_send![cls, alloc];
+    let obj: *mut AnyObject = msg_send![cls, alloc];
     msg_send![
         obj,
         initWithBytes: bytes

--- a/src/packages/notifications/ios.rs
+++ b/src/packages/notifications/ios.rs
@@ -137,16 +137,4 @@ pub fn cancel_all() -> Result<(), String> {
     }
 }
 
-/// Create an NSString from a Rust string slice.
-unsafe fn nsstring(s: &str) -> *mut AnyObject {
-    let cls = class!(NSString);
-    let bytes = s.as_ptr();
-    let len = s.len();
-    let obj: *mut AnyObject = msg_send![cls, alloc];
-    msg_send![
-        obj,
-        initWithBytes: bytes
-        length: len
-        encoding: 4u64 // NSUTF8StringEncoding
-    ]
-}
+use crate::ios::util::nsstring;

--- a/src/packages/package_info/ios.rs
+++ b/src/packages/package_info/ios.rs
@@ -1,16 +1,16 @@
 use super::PackageInfo;
-use objc::runtime::Object;
-use objc::{class, msg_send, sel, sel_impl};
+use objc2::runtime::AnyObject;
+use objc2::{class, msg_send, sel};
 use std::ffi::CStr;
 
 pub fn get_package_info() -> Result<PackageInfo, String> {
     unsafe {
-        let bundle: *mut Object = msg_send![class!(NSBundle), mainBundle];
+        let bundle: *mut AnyObject = msg_send![class!(NSBundle), mainBundle];
         if bundle.is_null() {
             return Err("Failed to get NSBundle.mainBundle".into());
         }
 
-        let info_dict: *mut Object = msg_send![bundle, infoDictionary];
+        let info_dict: *mut AnyObject = msg_send![bundle, infoDictionary];
         if info_dict.is_null() {
             return Err("Failed to get infoDictionary".into());
         }
@@ -34,9 +34,9 @@ pub fn get_package_info() -> Result<PackageInfo, String> {
     }
 }
 
-unsafe fn nsdict_string(dict: *mut Object, key: &str) -> Option<String> {
+unsafe fn nsdict_string(dict: *mut AnyObject, key: &str) -> Option<String> {
     let key_nsstring = nsstring(key);
-    let value: *mut Object = msg_send![dict, objectForKey: key_nsstring];
+    let value: *mut AnyObject = msg_send![dict, objectForKey: key_nsstring];
     if value.is_null() {
         return None;
     }
@@ -47,8 +47,8 @@ unsafe fn nsdict_string(dict: *mut Object, key: &str) -> Option<String> {
     Some(CStr::from_ptr(utf8).to_string_lossy().into_owned())
 }
 
-unsafe fn nsstring(s: &str) -> *mut Object {
-    let ns_string: *mut Object = msg_send![class!(NSString), alloc];
+unsafe fn nsstring(s: &str) -> *mut AnyObject {
+    let ns_string: *mut AnyObject = msg_send![class!(NSString), alloc];
     msg_send![ns_string, initWithBytes: s.as_ptr()
                          length: s.len()
                          encoding: 4u64] // NSUTF8StringEncoding

--- a/src/packages/package_info/ios.rs
+++ b/src/packages/package_info/ios.rs
@@ -47,9 +47,4 @@ unsafe fn nsdict_string(dict: *mut AnyObject, key: &str) -> Option<String> {
     Some(CStr::from_ptr(utf8).to_string_lossy().into_owned())
 }
 
-unsafe fn nsstring(s: &str) -> *mut AnyObject {
-    let ns_string: *mut AnyObject = msg_send![class!(NSString), alloc];
-    msg_send![ns_string, initWithBytes: s.as_ptr()
-                         length: s.len()
-                         encoding: 4u64] // NSUTF8StringEncoding
-}
+use crate::ios::util::nsstring;

--- a/src/packages/path_provider/ios.rs
+++ b/src/packages/path_provider/ios.rs
@@ -1,12 +1,12 @@
-use objc::runtime::Object;
-use objc::{msg_send, sel, sel_impl};
+use objc2::runtime::AnyObject;
+use objc2::{msg_send, sel};
 use std::ffi::CStr;
 use std::path::PathBuf;
 
 pub fn temporary_directory() -> Result<PathBuf, String> {
     unsafe {
         extern "C" {
-            fn NSTemporaryDirectory() -> *mut Object;
+            fn NSTemporaryDirectory() -> *mut AnyObject;
         }
         let path = NSTemporaryDirectory();
         nsstring_to_pathbuf(path)
@@ -33,7 +33,7 @@ fn search_path_directory(directory: u64) -> Result<PathBuf, String> {
                 directory: u64,
                 domain_mask: u64,
                 expand_tilde: bool,
-            ) -> *mut Object; // NSArray<NSString*>
+            ) -> *mut AnyObject; // NSArray<NSString*>
         }
 
         let array = NSSearchPathForDirectoriesInDomains(
@@ -49,12 +49,12 @@ fn search_path_directory(directory: u64) -> Result<PathBuf, String> {
             return Err("NSSearchPathForDirectoriesInDomains returned empty array".into());
         }
 
-        let first: *mut Object = msg_send![array, objectAtIndex: 0u64];
+        let first: *mut AnyObject = msg_send![array, objectAtIndex: 0u64];
         nsstring_to_pathbuf(first)
     }
 }
 
-unsafe fn nsstring_to_pathbuf(ns: *mut Object) -> Result<PathBuf, String> {
+unsafe fn nsstring_to_pathbuf(ns: *mut AnyObject) -> Result<PathBuf, String> {
     if ns.is_null() {
         return Err("NSString is nil".into());
     }

--- a/src/packages/permission_handler/ios.rs
+++ b/src/packages/permission_handler/ios.rs
@@ -153,8 +153,8 @@ unsafe fn check_notification_authorization() -> Result<PermissionStatus, String>
 
     let center: *mut AnyObject =
         msg_send![class!(UNUserNotificationCenter), currentNotificationCenter];
-    let block = block::ConcreteBlock::new(move |settings: *mut AnyObject| {
-        let auth_status: i64 = msg_send![settings, authorizationStatus];
+    let block = block2::RcBlock::new(move |settings: *mut AnyObject| {
+        let auth_status: i64 = unsafe { msg_send![settings, authorizationStatus] };
         let status = match auth_status {
             0 => PermissionStatus::Denied,  // UNAuthorizationStatusNotDetermined
             1 => PermissionStatus::Denied,  // UNAuthorizationStatusDenied
@@ -164,7 +164,6 @@ unsafe fn check_notification_authorization() -> Result<PermissionStatus, String>
         };
         let _ = tx.send(status);
     });
-    let block = block.copy();
     let _: () = msg_send![center, getNotificationSettingsWithCompletionHandler: &*block];
 
     rx.recv()
@@ -252,7 +251,7 @@ unsafe fn request_av_authorization(media_type: &str) -> Result<PermissionStatus,
     let (tx, rx) = mpsc::channel();
     let ns_media = nsstring(media_type);
 
-    let block = block::ConcreteBlock::new(move |granted: BOOL| {
+    let block = block2::RcBlock::new(move |granted: BOOL| {
         let status = if granted == YES {
             PermissionStatus::Granted
         } else {
@@ -260,7 +259,6 @@ unsafe fn request_av_authorization(media_type: &str) -> Result<PermissionStatus,
         };
         let _ = tx.send(status);
     });
-    let block = block.copy();
 
     let _: () = msg_send![class!(AVCaptureDevice),
         requestAccessForMediaType: ns_media
@@ -274,7 +272,7 @@ unsafe fn request_av_authorization(media_type: &str) -> Result<PermissionStatus,
 unsafe fn request_photos_authorization() -> Result<PermissionStatus, String> {
     let (tx, rx) = mpsc::channel();
 
-    let block = block::ConcreteBlock::new(move |status: i64| {
+    let block = block2::RcBlock::new(move |status: i64| {
         let perm = match status {
             0 => PermissionStatus::Denied,
             1 => PermissionStatus::Restricted,
@@ -285,7 +283,6 @@ unsafe fn request_photos_authorization() -> Result<PermissionStatus, String> {
         };
         let _ = tx.send(perm);
     });
-    let block = block.copy();
 
     let _: () = msg_send![class!(PHPhotoLibrary),
         requestAuthorizationForAccessLevel: 1i64 // PHAccessLevelReadWrite
@@ -318,7 +315,7 @@ unsafe fn request_contacts_authorization() -> Result<PermissionStatus, String> {
     let store: *mut AnyObject = msg_send![class!(CNContactStore), alloc];
     let store: *mut AnyObject = msg_send![store, init];
 
-    let block = block::ConcreteBlock::new(move |granted: BOOL, _error: *mut AnyObject| {
+    let block = block2::RcBlock::new(move |granted: BOOL, _error: *mut AnyObject| {
         let status = if granted == YES {
             PermissionStatus::Granted
         } else {
@@ -326,7 +323,6 @@ unsafe fn request_contacts_authorization() -> Result<PermissionStatus, String> {
         };
         let _ = tx.send(status);
     });
-    let block = block.copy();
 
     let _: () = msg_send![store,
         requestAccessForEntityType: 0i64 // CNEntityTypeContacts
@@ -342,7 +338,7 @@ unsafe fn request_event_authorization(entity_type: i64) -> Result<PermissionStat
     let store: *mut AnyObject = msg_send![class!(EKEventStore), alloc];
     let store: *mut AnyObject = msg_send![store, init];
 
-    let block = block::ConcreteBlock::new(move |granted: BOOL, _error: *mut AnyObject| {
+    let block = block2::RcBlock::new(move |granted: BOOL, _error: *mut AnyObject| {
         let status = if granted == YES {
             PermissionStatus::Granted
         } else {
@@ -350,7 +346,6 @@ unsafe fn request_event_authorization(entity_type: i64) -> Result<PermissionStat
         };
         let _ = tx.send(status);
     });
-    let block = block.copy();
 
     let _: () = msg_send![store,
         requestAccessToEntityType: entity_type
@@ -369,7 +364,7 @@ unsafe fn request_notification_authorization() -> Result<PermissionStatus, Strin
     // UNAuthorizationOptionAlert | UNAuthorizationOptionBadge | UNAuthorizationOptionSound
     let options: u64 = (1 << 0) | (1 << 1) | (1 << 2);
 
-    let block = block::ConcreteBlock::new(move |granted: BOOL, _error: *mut AnyObject| {
+    let block = block2::RcBlock::new(move |granted: BOOL, _error: *mut AnyObject| {
         let status = if granted == YES {
             PermissionStatus::Granted
         } else {
@@ -377,7 +372,6 @@ unsafe fn request_notification_authorization() -> Result<PermissionStatus, Strin
         };
         let _ = tx.send(status);
     });
-    let block = block.copy();
 
     let _: () = msg_send![center,
         requestAuthorizationWithOptions: options
@@ -391,7 +385,7 @@ unsafe fn request_notification_authorization() -> Result<PermissionStatus, Strin
 unsafe fn request_speech_authorization() -> Result<PermissionStatus, String> {
     let (tx, rx) = mpsc::channel();
 
-    let block = block::ConcreteBlock::new(move |status: i64| {
+    let block = block2::RcBlock::new(move |status: i64| {
         let perm = match status {
             0 => PermissionStatus::Denied,
             1 => PermissionStatus::Denied,
@@ -401,7 +395,6 @@ unsafe fn request_speech_authorization() -> Result<PermissionStatus, String> {
         };
         let _ = tx.send(perm);
     });
-    let block = block.copy();
 
     let _: () = msg_send![class!(SFSpeechRecognizer),
         requestAuthorization: &*block
@@ -414,7 +407,7 @@ unsafe fn request_speech_authorization() -> Result<PermissionStatus, String> {
 unsafe fn request_tracking_authorization() -> Result<PermissionStatus, String> {
     let (tx, rx) = mpsc::channel();
 
-    let block = block::ConcreteBlock::new(move |status: u32| {
+    let block = block2::RcBlock::new(move |status: u32| {
         let perm = match status {
             0 => PermissionStatus::Denied,
             1 => PermissionStatus::Restricted,
@@ -424,7 +417,6 @@ unsafe fn request_tracking_authorization() -> Result<PermissionStatus, String> {
         };
         let _ = tx.send(perm);
     });
-    let block = block.copy();
 
     let _: () = msg_send![class!(ATTrackingManager),
         requestTrackingAuthorizationWithCompletionHandler: &*block

--- a/src/packages/permission_handler/ios.rs
+++ b/src/packages/permission_handler/ios.rs
@@ -1,6 +1,7 @@
 use super::*;
-use objc::runtime::{Object, BOOL, YES};
-use objc::{class, msg_send, sel, sel_impl};
+use objc2::ffi::{BOOL, YES};
+use objc2::runtime::AnyObject;
+use objc2::{class, msg_send, sel};
 use std::sync::mpsc;
 
 #[link(name = "AVFoundation", kind = "framework")]
@@ -35,8 +36,8 @@ extern "C" {}
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-unsafe fn nsstring(s: &str) -> *mut Object {
-    let ns: *mut Object = msg_send![class!(NSString), alloc];
+unsafe fn nsstring(s: &str) -> *mut AnyObject {
+    let ns: *mut AnyObject = msg_send![class!(NSString), alloc];
     msg_send![ns,
         initWithBytes: s.as_ptr() as *const std::ffi::c_void
         length: s.len()
@@ -109,8 +110,8 @@ unsafe fn check_photos_authorization() -> Result<PermissionStatus, String> {
 }
 
 unsafe fn check_location_authorization() -> Result<PermissionStatus, String> {
-    let mgr: *mut Object = msg_send![class!(CLLocationManager), alloc];
-    let mgr: *mut Object = msg_send![mgr, init];
+    let mgr: *mut AnyObject = msg_send![class!(CLLocationManager), alloc];
+    let mgr: *mut AnyObject = msg_send![mgr, init];
     let status: i32 = msg_send![mgr, authorizationStatus];
     Ok(match status {
         0 => PermissionStatus::Denied, // kCLAuthorizationStatusNotDetermined
@@ -150,9 +151,9 @@ unsafe fn check_notification_authorization() -> Result<PermissionStatus, String>
     // UNUserNotificationCenter is async, so we use a sync channel
     let (tx, rx) = mpsc::channel();
 
-    let center: *mut Object =
+    let center: *mut AnyObject =
         msg_send![class!(UNUserNotificationCenter), currentNotificationCenter];
-    let block = block::ConcreteBlock::new(move |settings: *mut Object| {
+    let block = block::ConcreteBlock::new(move |settings: *mut AnyObject| {
         let auth_status: i64 = msg_send![settings, authorizationStatus];
         let status = match auth_status {
             0 => PermissionStatus::Denied,  // UNAuthorizationStatusNotDetermined
@@ -296,8 +297,8 @@ unsafe fn request_photos_authorization() -> Result<PermissionStatus, String> {
 }
 
 unsafe fn request_location_when_in_use() -> Result<PermissionStatus, String> {
-    let mgr: *mut Object = msg_send![class!(CLLocationManager), alloc];
-    let mgr: *mut Object = msg_send![mgr, init];
+    let mgr: *mut AnyObject = msg_send![class!(CLLocationManager), alloc];
+    let mgr: *mut AnyObject = msg_send![mgr, init];
     let _: () = msg_send![mgr, requestWhenInUseAuthorization];
     // Location authorization is async via delegate; return current status after a brief wait
     std::thread::sleep(std::time::Duration::from_millis(500));
@@ -305,8 +306,8 @@ unsafe fn request_location_when_in_use() -> Result<PermissionStatus, String> {
 }
 
 unsafe fn request_location_always() -> Result<PermissionStatus, String> {
-    let mgr: *mut Object = msg_send![class!(CLLocationManager), alloc];
-    let mgr: *mut Object = msg_send![mgr, init];
+    let mgr: *mut AnyObject = msg_send![class!(CLLocationManager), alloc];
+    let mgr: *mut AnyObject = msg_send![mgr, init];
     let _: () = msg_send![mgr, requestAlwaysAuthorization];
     std::thread::sleep(std::time::Duration::from_millis(500));
     check_location_authorization()
@@ -314,10 +315,10 @@ unsafe fn request_location_always() -> Result<PermissionStatus, String> {
 
 unsafe fn request_contacts_authorization() -> Result<PermissionStatus, String> {
     let (tx, rx) = mpsc::channel();
-    let store: *mut Object = msg_send![class!(CNContactStore), alloc];
-    let store: *mut Object = msg_send![store, init];
+    let store: *mut AnyObject = msg_send![class!(CNContactStore), alloc];
+    let store: *mut AnyObject = msg_send![store, init];
 
-    let block = block::ConcreteBlock::new(move |granted: BOOL, _error: *mut Object| {
+    let block = block::ConcreteBlock::new(move |granted: BOOL, _error: *mut AnyObject| {
         let status = if granted == YES {
             PermissionStatus::Granted
         } else {
@@ -338,10 +339,10 @@ unsafe fn request_contacts_authorization() -> Result<PermissionStatus, String> {
 
 unsafe fn request_event_authorization(entity_type: i64) -> Result<PermissionStatus, String> {
     let (tx, rx) = mpsc::channel();
-    let store: *mut Object = msg_send![class!(EKEventStore), alloc];
-    let store: *mut Object = msg_send![store, init];
+    let store: *mut AnyObject = msg_send![class!(EKEventStore), alloc];
+    let store: *mut AnyObject = msg_send![store, init];
 
-    let block = block::ConcreteBlock::new(move |granted: BOOL, _error: *mut Object| {
+    let block = block::ConcreteBlock::new(move |granted: BOOL, _error: *mut AnyObject| {
         let status = if granted == YES {
             PermissionStatus::Granted
         } else {
@@ -362,13 +363,13 @@ unsafe fn request_event_authorization(entity_type: i64) -> Result<PermissionStat
 
 unsafe fn request_notification_authorization() -> Result<PermissionStatus, String> {
     let (tx, rx) = mpsc::channel();
-    let center: *mut Object =
+    let center: *mut AnyObject =
         msg_send![class!(UNUserNotificationCenter), currentNotificationCenter];
 
     // UNAuthorizationOptionAlert | UNAuthorizationOptionBadge | UNAuthorizationOptionSound
     let options: u64 = (1 << 0) | (1 << 1) | (1 << 2);
 
-    let block = block::ConcreteBlock::new(move |granted: BOOL, _error: *mut Object| {
+    let block = block::ConcreteBlock::new(move |granted: BOOL, _error: *mut AnyObject| {
         let status = if granted == YES {
             PermissionStatus::Granted
         } else {
@@ -473,19 +474,19 @@ pub fn service_status(permission: Permission) -> Result<ServiceStatus, String> {
 pub fn open_app_settings() -> Result<bool, String> {
     unsafe {
         let url_string = nsstring("app-settings:");
-        let url: *mut Object = msg_send![class!(NSURL), URLWithString: url_string];
+        let url: *mut AnyObject = msg_send![class!(NSURL), URLWithString: url_string];
         if url.is_null() {
             return Err("Failed to create settings URL".into());
         }
 
-        let app: *mut Object = msg_send![class!(UIApplication), sharedApplication];
+        let app: *mut AnyObject = msg_send![class!(UIApplication), sharedApplication];
         let can_open: BOOL = msg_send![app, canOpenURL: url];
         if can_open != YES {
             return Ok(false);
         }
 
-        let empty_dict: *mut Object = msg_send![class!(NSDictionary), dictionary];
-        let nil: *mut Object = std::ptr::null_mut();
+        let empty_dict: *mut AnyObject = msg_send![class!(NSDictionary), dictionary];
+        let nil: *mut AnyObject = std::ptr::null_mut();
         let _: () = msg_send![app,
             openURL: url
             options: empty_dict

--- a/src/packages/permission_handler/ios.rs
+++ b/src/packages/permission_handler/ios.rs
@@ -36,14 +36,7 @@ extern "C" {}
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-unsafe fn nsstring(s: &str) -> *mut AnyObject {
-    let ns: *mut AnyObject = msg_send![class!(NSString), alloc];
-    msg_send![ns,
-        initWithBytes: s.as_ptr() as *const std::ffi::c_void
-        length: s.len()
-        encoding: 4u64
-    ]
-}
+use crate::ios::util::nsstring;
 
 // ── Check permission ────────────────────────────────────────────────────────
 

--- a/src/packages/sensors/ios.rs
+++ b/src/packages/sensors/ios.rs
@@ -1,6 +1,6 @@
 use super::{BarometerData, SensorAvailability, SensorData};
-use objc::runtime::Object;
-use objc::{class, msg_send, sel, sel_impl};
+use objc2::runtime::AnyObject;
+use objc2::{class, msg_send, sel};
 
 pub fn available_sensors() -> SensorAvailability {
     unsafe {
@@ -37,7 +37,7 @@ pub fn accelerometer() -> Option<SensorData> {
             std::thread::sleep(std::time::Duration::from_millis(50));
         }
 
-        let data: *mut Object = msg_send![manager, accelerometerData];
+        let data: *mut AnyObject = msg_send![manager, accelerometerData];
         if data.is_null() {
             return None;
         }
@@ -64,7 +64,7 @@ pub fn gyroscope() -> Option<SensorData> {
             std::thread::sleep(std::time::Duration::from_millis(50));
         }
 
-        let data: *mut Object = msg_send![manager, gyroData];
+        let data: *mut AnyObject = msg_send![manager, gyroData];
         if data.is_null() {
             return None;
         }
@@ -90,7 +90,7 @@ pub fn magnetometer() -> Option<SensorData> {
             std::thread::sleep(std::time::Duration::from_millis(50));
         }
 
-        let data: *mut Object = msg_send![manager, magnetometerData];
+        let data: *mut AnyObject = msg_send![manager, magnetometerData];
         if data.is_null() {
             return None;
         }
@@ -139,14 +139,14 @@ struct CMMagneticField {
 /// Get or create a shared CMMotionManager instance.
 ///
 /// CMMotionManager should be a singleton per app.
-unsafe fn get_motion_manager() -> *mut Object {
+unsafe fn get_motion_manager() -> *mut AnyObject {
     use std::sync::OnceLock;
     static MANAGER: OnceLock<usize> = OnceLock::new();
 
     let ptr = MANAGER.get_or_init(|| {
-        let manager: *mut Object = msg_send![class!(CMMotionManager), alloc];
-        let manager: *mut Object = msg_send![manager, init];
+        let manager: *mut AnyObject = msg_send![class!(CMMotionManager), alloc];
+        let manager: *mut AnyObject = msg_send![manager, init];
         manager as usize
     });
-    *ptr as *mut Object
+    *ptr as *mut AnyObject
 }

--- a/src/packages/sensors/ios.rs
+++ b/src/packages/sensors/ios.rs
@@ -1,4 +1,5 @@
 use super::{BarometerData, SensorAvailability, SensorData};
+use objc2::encode::{Encode, Encoding, RefEncode};
 use objc2::runtime::AnyObject;
 use objc2::{class, msg_send, sel};
 
@@ -112,6 +113,21 @@ pub fn barometer() -> Option<BarometerData> {
 }
 
 // CoreMotion types
+
+macro_rules! encode_xyz_struct {
+    ($name:ident) => {
+        unsafe impl Encode for $name {
+            const ENCODING: Encoding = Encoding::Struct(
+                stringify!($name),
+                &[Encoding::Double, Encoding::Double, Encoding::Double],
+            );
+        }
+        unsafe impl RefEncode for $name {
+            const ENCODING_REF: Encoding = Encoding::Pointer(&Self::ENCODING);
+        }
+    };
+}
+
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 struct CMAcceleration {
@@ -119,6 +135,7 @@ struct CMAcceleration {
     y: f64,
     z: f64,
 }
+encode_xyz_struct!(CMAcceleration);
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
@@ -127,6 +144,7 @@ struct CMRotationRate {
     y: f64,
     z: f64,
 }
+encode_xyz_struct!(CMRotationRate);
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
@@ -135,6 +153,7 @@ struct CMMagneticField {
     y: f64,
     z: f64,
 }
+encode_xyz_struct!(CMMagneticField);
 
 /// Get or create a shared CMMotionManager instance.
 ///

--- a/src/packages/share/ios.rs
+++ b/src/packages/share/ios.rs
@@ -1,17 +1,17 @@
-use objc::runtime::Object;
-use objc::{class, msg_send, sel, sel_impl};
+use objc2::runtime::AnyObject;
+use objc2::{class, msg_send, sel};
 
 pub fn share_text(text: &str, _subject: Option<&str>) -> Result<(), String> {
     unsafe {
         // NSString *shareText = @"...";
-        let ns_text: *mut Object = msg_send![
+        let ns_text: *mut AnyObject = msg_send![
             class!(NSString),
             stringWithUTF8String: text.as_ptr() as *const std::ffi::c_char
         ];
         if ns_text.is_null() {
             // Fallback: use alloc + initWithBytes for non-null-terminated strings
-            let ns_text: *mut Object = msg_send![class!(NSString), alloc];
-            let ns_text: *mut Object = msg_send![ns_text,
+            let ns_text: *mut AnyObject = msg_send![class!(NSString), alloc];
+            let ns_text: *mut AnyObject = msg_send![ns_text,
                 initWithBytes: text.as_ptr() as *const std::ffi::c_void
                 length: text.len()
                 encoding: 4u64  // NSUTF8StringEncoding
@@ -25,18 +25,18 @@ pub fn share_text(text: &str, _subject: Option<&str>) -> Result<(), String> {
     }
 }
 
-unsafe fn present_share_sheet(text: *mut Object) -> Result<(), String> {
+unsafe fn present_share_sheet(text: *mut AnyObject) -> Result<(), String> {
     // NSArray *items = @[text];
-    let items: *mut Object = msg_send![class!(NSArray), arrayWithObject: text];
+    let items: *mut AnyObject = msg_send![class!(NSArray), arrayWithObject: text];
     if items.is_null() {
         return Err("Failed to create NSArray".into());
     }
 
     // UIActivityViewController *vc = [[UIActivityViewController alloc]
     //     initWithActivityItems:items applicationActivities:nil];
-    let vc: *mut Object = msg_send![class!(UIActivityViewController), alloc];
-    let nil: *mut Object = std::ptr::null_mut();
-    let vc: *mut Object = msg_send![vc,
+    let vc: *mut AnyObject = msg_send![class!(UIActivityViewController), alloc];
+    let nil: *mut AnyObject = std::ptr::null_mut();
+    let vc: *mut AnyObject = msg_send![vc,
         initWithActivityItems: items
         applicationActivities: nil
     ];
@@ -45,12 +45,12 @@ unsafe fn present_share_sheet(text: *mut Object) -> Result<(), String> {
     }
 
     // Get the root view controller to present from.
-    let app: *mut Object = msg_send![class!(UIApplication), sharedApplication];
-    let key_window: *mut Object = msg_send![app, keyWindow];
+    let app: *mut AnyObject = msg_send![class!(UIApplication), sharedApplication];
+    let key_window: *mut AnyObject = msg_send![app, keyWindow];
     if key_window.is_null() {
         return Err("No key window available".into());
     }
-    let root_vc: *mut Object = msg_send![key_window, rootViewController];
+    let root_vc: *mut AnyObject = msg_send![key_window, rootViewController];
     if root_vc.is_null() {
         return Err("No root view controller".into());
     }

--- a/src/packages/shared_preferences/ios.rs
+++ b/src/packages/shared_preferences/ios.rs
@@ -123,14 +123,7 @@ unsafe fn user_defaults() -> *mut AnyObject {
     msg_send![class!(NSUserDefaults), standardUserDefaults]
 }
 
-unsafe fn nsstring(s: &str) -> *mut AnyObject {
-    let ns: *mut AnyObject = msg_send![class!(NSString), alloc];
-    let ns: *mut AnyObject = msg_send![ns, initWithBytes: s.as_ptr()
-                  length: s.len()
-                  encoding: 4u64]; // NSUTF8StringEncoding
-                                   // autorelease so callers don't need to manage the lifetime manually
-    msg_send![ns, autorelease]
-}
+use crate::ios::util::nsstring;
 
 unsafe fn nsstring_to_string(ns: *mut AnyObject) -> String {
     let utf8: *const i8 = msg_send![ns, UTF8String];

--- a/src/packages/shared_preferences/ios.rs
+++ b/src/packages/shared_preferences/ios.rs
@@ -1,5 +1,5 @@
-use objc::runtime::Object;
-use objc::{class, msg_send, sel, sel_impl};
+use objc2::runtime::AnyObject;
+use objc2::{class, msg_send, sel};
 use std::ffi::CStr;
 
 pub struct IosSharedPreferences;
@@ -13,7 +13,7 @@ impl IosSharedPreferences {
         unsafe {
             let defaults = user_defaults();
             let ns_key = nsstring(key);
-            let value: *mut Object = msg_send![defaults, stringForKey: ns_key];
+            let value: *mut AnyObject = msg_send![defaults, stringForKey: ns_key];
             if value.is_null() {
                 None
             } else {
@@ -37,7 +37,7 @@ impl IosSharedPreferences {
         unsafe {
             let defaults = user_defaults();
             let ns_key = nsstring(key);
-            let obj: *mut Object = msg_send![defaults, objectForKey: ns_key];
+            let obj: *mut AnyObject = msg_send![defaults, objectForKey: ns_key];
             if obj.is_null() {
                 None
             } else {
@@ -61,7 +61,7 @@ impl IosSharedPreferences {
         unsafe {
             let defaults = user_defaults();
             let ns_key = nsstring(key);
-            let obj: *mut Object = msg_send![defaults, objectForKey: ns_key];
+            let obj: *mut AnyObject = msg_send![defaults, objectForKey: ns_key];
             if obj.is_null() {
                 None
             } else {
@@ -94,14 +94,14 @@ impl IosSharedPreferences {
     pub fn clear(&self) -> Result<(), String> {
         unsafe {
             let defaults = user_defaults();
-            let dict: *mut Object = msg_send![defaults, dictionaryRepresentation];
+            let dict: *mut AnyObject = msg_send![defaults, dictionaryRepresentation];
             if dict.is_null() {
                 return Ok(());
             }
-            let keys: *mut Object = msg_send![dict, allKeys];
+            let keys: *mut AnyObject = msg_send![dict, allKeys];
             let count: u64 = msg_send![keys, count];
             for i in 0..count {
-                let key: *mut Object = msg_send![keys, objectAtIndex: i];
+                let key: *mut AnyObject = msg_send![keys, objectAtIndex: i];
                 let _: () = msg_send![defaults, removeObjectForKey: key];
             }
             let _: () = msg_send![defaults, synchronize];
@@ -113,24 +113,24 @@ impl IosSharedPreferences {
         unsafe {
             let defaults = user_defaults();
             let ns_key = nsstring(key);
-            let obj: *mut Object = msg_send![defaults, objectForKey: ns_key];
+            let obj: *mut AnyObject = msg_send![defaults, objectForKey: ns_key];
             !obj.is_null()
         }
     }
 }
 
-unsafe fn user_defaults() -> *mut Object {
+unsafe fn user_defaults() -> *mut AnyObject {
     msg_send![class!(NSUserDefaults), standardUserDefaults]
 }
 
-unsafe fn nsstring(s: &str) -> *mut Object {
-    let ns: *mut Object = msg_send![class!(NSString), alloc];
+unsafe fn nsstring(s: &str) -> *mut AnyObject {
+    let ns: *mut AnyObject = msg_send![class!(NSString), alloc];
     msg_send![ns, initWithBytes: s.as_ptr()
                   length: s.len()
                   encoding: 4u64] // NSUTF8StringEncoding
 }
 
-unsafe fn nsstring_to_string(ns: *mut Object) -> String {
+unsafe fn nsstring_to_string(ns: *mut AnyObject) -> String {
     let utf8: *const i8 = msg_send![ns, UTF8String];
     if utf8.is_null() {
         return String::new();

--- a/src/packages/shared_preferences/ios.rs
+++ b/src/packages/shared_preferences/ios.rs
@@ -125,9 +125,11 @@ unsafe fn user_defaults() -> *mut AnyObject {
 
 unsafe fn nsstring(s: &str) -> *mut AnyObject {
     let ns: *mut AnyObject = msg_send![class!(NSString), alloc];
-    msg_send![ns, initWithBytes: s.as_ptr()
+    let ns: *mut AnyObject = msg_send![ns, initWithBytes: s.as_ptr()
                   length: s.len()
-                  encoding: 4u64] // NSUTF8StringEncoding
+                  encoding: 4u64]; // NSUTF8StringEncoding
+                                   // autorelease so callers don't need to manage the lifetime manually
+    msg_send![ns, autorelease]
 }
 
 unsafe fn nsstring_to_string(ns: *mut AnyObject) -> String {

--- a/src/packages/url_launcher/ios.rs
+++ b/src/packages/url_launcher/ios.rs
@@ -1,10 +1,10 @@
-use objc::runtime::Object;
-use objc::{class, msg_send, sel, sel_impl};
+use objc2::runtime::AnyObject;
+use objc2::{class, msg_send, sel};
 
 pub fn launch_url(url: &str) -> Result<bool, String> {
     unsafe {
         let nsurl = nsurl_from_str(url)?;
-        let app: *mut Object = msg_send![class!(UIApplication), sharedApplication];
+        let app: *mut AnyObject = msg_send![class!(UIApplication), sharedApplication];
         if app.is_null() {
             return Err("Failed to get UIApplication.sharedApplication".into());
         }
@@ -16,7 +16,7 @@ pub fn launch_url(url: &str) -> Result<bool, String> {
 pub fn can_launch_url(url: &str) -> Result<bool, String> {
     unsafe {
         let nsurl = nsurl_from_str(url)?;
-        let app: *mut Object = msg_send![class!(UIApplication), sharedApplication];
+        let app: *mut AnyObject = msg_send![class!(UIApplication), sharedApplication];
         if app.is_null() {
             return Err("Failed to get UIApplication.sharedApplication".into());
         }
@@ -25,15 +25,15 @@ pub fn can_launch_url(url: &str) -> Result<bool, String> {
     }
 }
 
-unsafe fn nsurl_from_str(url: &str) -> Result<*mut Object, String> {
-    let ns_string: *mut Object = msg_send![class!(NSString), alloc];
-    let ns_string: *mut Object = msg_send![ns_string, initWithBytes: url.as_ptr()
+unsafe fn nsurl_from_str(url: &str) -> Result<*mut AnyObject, String> {
+    let ns_string: *mut AnyObject = msg_send![class!(NSString), alloc];
+    let ns_string: *mut AnyObject = msg_send![ns_string, initWithBytes: url.as_ptr()
                                                        length: url.len()
                                                        encoding: 4u64];
     if ns_string.is_null() {
         return Err("Failed to create NSString from URL".into());
     }
-    let nsurl: *mut Object = msg_send![class!(NSURL), URLWithString: ns_string];
+    let nsurl: *mut AnyObject = msg_send![class!(NSURL), URLWithString: ns_string];
     if nsurl.is_null() {
         return Err(format!("Failed to parse URL: {url}"));
     }

--- a/src/packages/url_launcher/ios.rs
+++ b/src/packages/url_launcher/ios.rs
@@ -34,6 +34,8 @@ unsafe fn nsurl_from_str(url: &str) -> Result<*mut AnyObject, String> {
         return Err("Failed to create NSString from URL".into());
     }
     let nsurl: *mut AnyObject = msg_send![class!(NSURL), URLWithString: ns_string];
+    // ns_string was alloc+init (retained); release now that URLWithString: has consumed it
+    let _: () = msg_send![ns_string, release];
     if nsurl.is_null() {
         return Err(format!("Failed to parse URL: {url}"));
     }

--- a/src/packages/vibration/ios.rs
+++ b/src/packages/vibration/ios.rs
@@ -1,6 +1,6 @@
 use super::HapticFeedback;
-use objc::runtime::Object;
-use objc::{class, msg_send, sel, sel_impl};
+use objc2::runtime::AnyObject;
+use objc2::{class, msg_send, sel};
 
 #[link(name = "AudioToolbox", kind = "framework")]
 extern "C" {}
@@ -38,8 +38,8 @@ pub fn can_vibrate() -> bool {
 }
 
 unsafe fn impact_feedback(style: i64) -> Result<(), String> {
-    let generator: *mut Object = msg_send![class!(UIImpactFeedbackGenerator), alloc];
-    let generator: *mut Object = msg_send![generator, initWithStyle: style];
+    let generator: *mut AnyObject = msg_send![class!(UIImpactFeedbackGenerator), alloc];
+    let generator: *mut AnyObject = msg_send![generator, initWithStyle: style];
     if generator.is_null() {
         return Err("Failed to create UIImpactFeedbackGenerator".into());
     }
@@ -49,8 +49,8 @@ unsafe fn impact_feedback(style: i64) -> Result<(), String> {
 }
 
 unsafe fn selection_feedback() -> Result<(), String> {
-    let generator: *mut Object = msg_send![class!(UISelectionFeedbackGenerator), alloc];
-    let generator: *mut Object = msg_send![generator, init];
+    let generator: *mut AnyObject = msg_send![class!(UISelectionFeedbackGenerator), alloc];
+    let generator: *mut AnyObject = msg_send![generator, init];
     if generator.is_null() {
         return Err("Failed to create UISelectionFeedbackGenerator".into());
     }
@@ -60,8 +60,8 @@ unsafe fn selection_feedback() -> Result<(), String> {
 }
 
 unsafe fn notification_feedback(type_: i64) -> Result<(), String> {
-    let generator: *mut Object = msg_send![class!(UINotificationFeedbackGenerator), alloc];
-    let generator: *mut Object = msg_send![generator, init];
+    let generator: *mut AnyObject = msg_send![class!(UINotificationFeedbackGenerator), alloc];
+    let generator: *mut AnyObject = msg_send![generator, init];
     if generator.is_null() {
         return Err("Failed to create UINotificationFeedbackGenerator".into());
     }

--- a/src/packages/video_player/ios.rs
+++ b/src/packages/video_player/ios.rs
@@ -287,15 +287,8 @@ fn cmtime_to_ms(time: CMTime) -> u64 {
     ((time.value as f64 / time.timescale as f64) * 1000.0).max(0.0) as u64
 }
 
-/// Create a retained NSString from a Rust `&str`.
 unsafe fn make_nsstring(s: &str) -> *mut AnyObject {
-    let nsstring_class = class!(NSString);
-    let bytes = s.as_ptr();
-    let len = s.len();
-    // NSUTF8StringEncoding = 4
-    let obj: *mut AnyObject = msg_send![nsstring_class, alloc];
-    let obj: *mut AnyObject = msg_send![obj, initWithBytes:bytes length:len encoding:4u64];
-    obj
+    crate::ios::util::nsstring(s)
 }
 
 /// Wait (up to 5 seconds) for the current AVPlayerItem to reach ReadyToPlay status.

--- a/src/packages/video_player/ios.rs
+++ b/src/packages/video_player/ios.rs
@@ -1,4 +1,5 @@
 use super::VideoInfo;
+use objc2::encode::{Encode, Encoding, RefEncode};
 use objc2::runtime::AnyObject;
 use objc2::{class, msg_send, sel};
 use std::collections::HashMap;
@@ -225,12 +226,37 @@ struct CMTime {
     epoch: i64,
 }
 
+unsafe impl Encode for CMTime {
+    const ENCODING: Encoding = Encoding::Struct(
+        "CMTime",
+        &[
+            Encoding::LongLong,
+            Encoding::Int,
+            Encoding::UInt,
+            Encoding::LongLong,
+        ],
+    );
+}
+
+unsafe impl RefEncode for CMTime {
+    const ENCODING_REF: Encoding = Encoding::Pointer(&Self::ENCODING);
+}
+
 /// CGSize layout.
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 struct CGSize {
     width: f64,
     height: f64,
+}
+
+unsafe impl Encode for CGSize {
+    const ENCODING: Encoding =
+        Encoding::Struct("CGSize", &[Encoding::Double, Encoding::Double]);
+}
+
+unsafe impl RefEncode for CGSize {
+    const ENCODING_REF: Encoding = Encoding::Pointer(&Self::ENCODING);
 }
 
 /// CMTime flag indicating a valid time.

--- a/src/packages/video_player/ios.rs
+++ b/src/packages/video_player/ios.rs
@@ -1,6 +1,6 @@
 use super::VideoInfo;
-use objc::runtime::Object;
-use objc::{class, msg_send, sel, sel_impl};
+use objc2::runtime::AnyObject;
+use objc2::{class, msg_send, sel};
 use std::collections::HashMap;
 use std::sync::Mutex;
 
@@ -12,7 +12,7 @@ static NEXT_ID: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new
 
 struct PlayerEntry {
     /// The AVPlayer instance (retained).
-    player: *mut Object,
+    player: *mut AnyObject,
     /// Whether looping is enabled.
     looping: bool,
 }
@@ -39,8 +39,8 @@ fn with_player<T>(
 /// Create a new AVPlayer and return its ID.
 pub fn create_player() -> Result<u32, String> {
     unsafe {
-        let player: *mut Object = msg_send![class!(AVPlayer), alloc];
-        let player: *mut Object = msg_send![player, init];
+        let player: *mut AnyObject = msg_send![class!(AVPlayer), alloc];
+        let player: *mut AnyObject = msg_send![player, init];
         if player.is_null() {
             return Err("Failed to create AVPlayer".into());
         }
@@ -63,20 +63,20 @@ pub fn create_player() -> Result<u32, String> {
 /// Get the raw AVPlayer pointer for a given player ID.
 ///
 /// Used by the platform view system to create AVPlayerLayer.
-pub fn get_player_ptr(id: u32) -> Option<*mut Object> {
+pub fn get_player_ptr(id: u32) -> Option<*mut AnyObject> {
     with_players(|map| map.get(&id).map(|entry| entry.player))
 }
 
 pub fn set_url(id: u32, url: &str) -> Result<VideoInfo, String> {
     with_player(id, |entry| unsafe {
         let url_str = make_nsstring(url);
-        let nsurl: *mut Object = msg_send![class!(NSURL), URLWithString: url_str];
+        let nsurl: *mut AnyObject = msg_send![class!(NSURL), URLWithString: url_str];
         if nsurl.is_null() {
             let _: () = msg_send![url_str, release];
             return Err("Invalid URL".into());
         }
 
-        let item: *mut Object = msg_send![class!(AVPlayerItem), playerItemWithURL: nsurl];
+        let item: *mut AnyObject = msg_send![class!(AVPlayerItem), playerItemWithURL: nsurl];
         let _: () = msg_send![entry.player, replaceCurrentItemWithPlayerItem: item];
         let _: () = msg_send![url_str, release];
 
@@ -88,13 +88,13 @@ pub fn set_url(id: u32, url: &str) -> Result<VideoInfo, String> {
 pub fn set_file_path(id: u32, path: &str) -> Result<VideoInfo, String> {
     with_player(id, |entry| unsafe {
         let path_str = make_nsstring(path);
-        let nsurl: *mut Object = msg_send![class!(NSURL), fileURLWithPath: path_str];
+        let nsurl: *mut AnyObject = msg_send![class!(NSURL), fileURLWithPath: path_str];
         if nsurl.is_null() {
             let _: () = msg_send![path_str, release];
             return Err("Invalid file path".into());
         }
 
-        let item: *mut Object = msg_send![class!(AVPlayerItem), playerItemWithURL: nsurl];
+        let item: *mut AnyObject = msg_send![class!(AVPlayerItem), playerItemWithURL: nsurl];
         let _: () = msg_send![entry.player, replaceCurrentItemWithPlayerItem: item];
         let _: () = msg_send![path_str, release];
 
@@ -175,7 +175,7 @@ pub fn position(id: u32) -> Result<u64, String> {
 
 pub fn duration(id: u32) -> Result<u64, String> {
     with_player(id, |entry| unsafe {
-        let item: *mut Object = msg_send![entry.player, currentItem];
+        let item: *mut AnyObject = msg_send![entry.player, currentItem];
         if item.is_null() {
             return Err("No current item".into());
         }
@@ -186,7 +186,7 @@ pub fn duration(id: u32) -> Result<u64, String> {
 
 pub fn video_size(id: u32) -> Result<(u32, u32), String> {
     with_player(id, |entry| unsafe {
-        let item: *mut Object = msg_send![entry.player, currentItem];
+        let item: *mut AnyObject = msg_send![entry.player, currentItem];
         if item.is_null() {
             return Err("No current item".into());
         }
@@ -263,19 +263,19 @@ fn cmtime_to_ms(time: CMTime) -> u64 {
 }
 
 /// Create a retained NSString from a Rust `&str`.
-unsafe fn make_nsstring(s: &str) -> *mut Object {
+unsafe fn make_nsstring(s: &str) -> *mut AnyObject {
     let nsstring_class = class!(NSString);
     let bytes = s.as_ptr();
     let len = s.len();
     // NSUTF8StringEncoding = 4
-    let obj: *mut Object = msg_send![nsstring_class, alloc];
-    let obj: *mut Object = msg_send![obj, initWithBytes:bytes length:len encoding:4u64];
+    let obj: *mut AnyObject = msg_send![nsstring_class, alloc];
+    let obj: *mut AnyObject = msg_send![obj, initWithBytes:bytes length:len encoding:4u64];
     obj
 }
 
 /// Wait (up to 5 seconds) for the current AVPlayerItem to reach ReadyToPlay status.
-unsafe fn wait_for_item_ready(player: *mut Object) -> Result<(), String> {
-    let item: *mut Object = msg_send![player, currentItem];
+unsafe fn wait_for_item_ready(player: *mut AnyObject) -> Result<(), String> {
+    let item: *mut AnyObject = msg_send![player, currentItem];
     if item.is_null() {
         return Err("No player item".into());
     }
@@ -293,8 +293,8 @@ unsafe fn wait_for_item_ready(player: *mut Object) -> Result<(), String> {
 }
 
 /// Extract video info from the current player item.
-unsafe fn get_video_info(player: *mut Object) -> Result<VideoInfo, String> {
-    let item: *mut Object = msg_send![player, currentItem];
+unsafe fn get_video_info(player: *mut AnyObject) -> Result<VideoInfo, String> {
+    let item: *mut AnyObject = msg_send![player, currentItem];
     if item.is_null() {
         return Err("No player item".into());
     }

--- a/src/packages/video_player/ios.rs
+++ b/src/packages/video_player/ios.rs
@@ -251,8 +251,7 @@ struct CGSize {
 }
 
 unsafe impl Encode for CGSize {
-    const ENCODING: Encoding =
-        Encoding::Struct("CGSize", &[Encoding::Double, Encoding::Double]);
+    const ENCODING: Encoding = Encoding::Struct("CGSize", &[Encoding::Double, Encoding::Double]);
 }
 
 unsafe impl RefEncode for CGSize {

--- a/src/packages/video_player/mod.rs
+++ b/src/packages/video_player/mod.rs
@@ -90,7 +90,7 @@ fn ensure_factory_registered() {
 /// Used by `IosPlatformView` to create an `AVPlayerLayer` during
 /// platform view construction.
 #[cfg(target_os = "ios")]
-pub fn ios_get_player(id: u32) -> Option<*mut objc::runtime::Object> {
+pub fn ios_get_player(id: u32) -> Option<*mut objc2::runtime::AnyObject> {
     ios::get_player_ptr(id)
 }
 


### PR DESCRIPTION
## Summary

Complete migration of all iOS-specific code from the unmaintained \`objc 0.2\` crate to the actively maintained \`objc2 0.6\` successor, fixing #31.

### Changes

- **\`Cargo.toml\` / \`example/Cargo.toml\`**: \`objc = \"0.2\"\` → \`objc2 = \"0.6\"\`, \`block = \"0.1\"\` → \`block2 = \"0.6\"\`
- **All iOS source files** (\`src/ios/\`, \`src/packages/*/ios.rs\`):
  - \`Object\` → \`AnyObject\`, \`Class\` → \`AnyClass\`, \`ClassDecl\` → \`ClassBuilder\`, \`Protocol\` → \`AnyProtocol\`
  - \`BOOL\`/\`YES\`/\`NO\` moved from \`objc::runtime\` to \`objc2::ffi\`
  - \`sel_impl!\` macro removed (no longer required in objc2)
  - Import paths updated throughout
- **\`src/ios/cg_types.rs\`** (new): local \`ObjcCGRect\`/\`ObjcCGPoint\`/\`ObjcCGSize\` wrappers with \`unsafe impl Encode\` since \`core-graphics\` types don't implement \`objc2::Encode\`
- **\`set_ivar\` removed**: replaced with \`*this.get_mut_ivar::<T>(name) = value\` pattern
- **\`ClassBuilder::new\` / \`add_ivar\` / \`AnyProtocol::get\`**: updated from \`&str\` to \`c\"...\"\` CStr literals (objc2 0.6 API change)
- **\`block2\` migration**: \`ConcreteBlock::new(...).copy()\` → \`RcBlock::new(...)\`; added explicit \`unsafe {}\` for \`msg_send!\` inside block closures
- **\`MethodImplementation\` HRTB fix**: changed all \`add_method\` callback receivers from \`&AnyObject\`/\`&mut AnyObject\` to \`*mut AnyObject\` — raw pointers avoid the \`for<'a>\` lifetime issue
- **\`unsafe impl Encode\`** added for: \`CMTime\`, \`CMAcceleration\`, \`CMRotationRate\`, \`CMMagneticField\`, \`CLLocationCoordinate2D\`, \`CGSize\`, \`UIEdgeInsets\`
- **\`IntoBlock\` fix**: \`bool\`/\`*mut bool\` block params → \`Bool\`/\`*mut Bool\` (use \`objc2::runtime::Bool\`)
- **Non-primitive cast fix**: \`false as BOOL\` → \`Bool::from(false)\`

### Result

\`cargo check --target aarch64-apple-ios\` — **zero errors**, zero clippy warnings.

## Test plan

- [x] \`cargo check --target aarch64-apple-ios\` passes with zero errors
- [x] \`cargo clippy --target aarch64-apple-ios\` passes with zero warnings
- [x] \`cargo fmt\` applied
- [ ] iOS simulator build succeeds via \`example/build.sh ios\`
- [x] No \`objc\` 0.2 imports remain in any iOS-gated code